### PR TITLE
강두오 3일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_2818/Main.java
+++ b/duoh/ALGO/src/boj_2818/Main.java
@@ -1,0 +1,47 @@
+package boj_2818;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int R = Integer.parseInt(st.nextToken());
+		int C = Integer.parseInt(st.nextToken());
+
+		int top = 1, front = 2, right = 3;
+		long sum = 1;
+
+		for (int row = 0; row < R; row++) {
+			if (row % 2 == 0) {
+				for (int col = 1; col < C; col++) {
+					int tmp = top;
+					top = 7 - right;
+					right = tmp;
+					sum += top;
+				}
+			} else {
+				for (int col = C - 2; col >= 0; col--) {
+					int tmp = top;
+					top = right;
+					right = 7 - tmp;
+					sum += top;
+				}
+			}
+
+			if (row < R - 1) {
+				int tmp = top;
+				top = 7 - front;
+				front = tmp;
+				sum += top;
+			}
+		}
+
+		System.out.println(sum);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[2818 숙제하기 싫을 때](https://www.acmicpc.net/problem/2818)

## 풀이

### 풀이에 대한 직관적인 설명

주사위를 굴리며 윗면 값을 모두 더하는 문제이다.

### 풀이 도출 과정

- 주사위의 초기 상태 설정 `(top = 1, front = 2, right = 3)`
- 다음을 반복
  - 짝수 행에서는 오른쪽으로, 홀수 행에서는 왼쪽으로 굴림
  - 행의 마지막 열에서는 아래로 굴림
- 주사위를 굴릴 때마다 `top` 값을 누적하여 합산

> 시뮬레이션으로 풀었지만, 일정한 패턴이 보인다. 패턴을 분석해서 풀이하면 더 효율적일듯..

## 복잡도

* 시간복잡도: O(R * C)

주어진 행렬 순회

## 채점 결과
<img width="940" alt="스크린샷 2024-12-09 오후 2 10 24" src="https://github.com/user-attachments/assets/47b08918-8c81-4ff3-b04e-712fd9b43a2e">