### PR TITLE
강두오 문제 풀이 6일차

### DIFF
--- a/duoh/ALGO/src/boj_2879/Main.java
+++ b/duoh/ALGO/src/boj_2879/Main.java
@@ -1,0 +1,52 @@
+package boj_2879;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int N = Integer.parseInt(br.readLine());
+		int[] diff = new int[N];
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++)
+			diff[i] = Integer.parseInt(st.nextToken());
+
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++)
+			diff[i] -= Integer.parseInt(st.nextToken());
+
+		int count = 0;
+		while (true) {
+			boolean flag = false;
+
+			for (int i = 0; i < N; i++) {
+				if (diff[i] == 0) continue;
+
+				flag = true;
+				int v = diff[i], j = i;
+
+				while (j < N && diff[i] * diff[j] > 0) {
+					if (Math.abs(diff[j]) < Math.abs(v))
+						v = diff[j];
+					j++;
+				}
+
+				for (int k = i; k < j; k++)
+					diff[k] -= v;
+
+				count += Math.abs(v);
+				i = j - 1;
+			}
+
+			if (!flag) break;
+		}
+
+		System.out.println(count);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[2879 코딩은 예쁘게](https://www.acmicpc.net/problem/2879)

## 풀이

### 풀이에 대한 직관적인 설명

탭 차이를 최소 작업으로 조정하는 문제이다.

### 풀이 도출 과정

- 두 배열의 차이를 `diff` 배열에 저장
- `flag`로 작업 여부를 판별하며 반복
  - `diff` 배열의 연속된 같은 부호 구간을 탐색
    - 최소 절댓값만큼 구간의 값 조정
    - 횟수 누적

> 아이디어는 단순한데, 구현이 까다로움..

## 복잡도

* 시간복잡도: O(N^2)

최대 N번의 반복 구간에서 구간 탐색, 조정을 수행하므로 최악의 경우 O(N^2)

## 채점 결과
<img width="940" alt="스크린샷 2024-12-13 오후 5 37 34" src="https://github.com/user-attachments/assets/9b540088-d83b-4025-b788-19e03cb2287e" />