### PR TITLE
오동재 7일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_2212/Main.java
+++ b/dongjae/ALGO/src/boj_2212/Main.java
@@ -1,0 +1,40 @@
+package boj_2212;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int n, k;
+    public static ArrayList<Integer> sensors = new ArrayList<>();
+    public static ArrayList<Integer> distances = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        k = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            sensors.add(Integer.parseInt(st.nextToken()));
+        }
+
+        if (k >= n) {
+            System.out.println(0);
+        } else {
+            Collections.sort(sensors);
+
+            for (int i = 1; i < sensors.size(); i++) {
+                distances.add(sensors.get(i) - sensors.get(i - 1));
+            }
+
+            Collections.sort(distances);
+
+            int sum = 0;
+            for (int i = 0; i < distances.size() - (k - 1); i++) {
+                sum += distances.get(i);
+            }
+
+            System.out.println(sum);
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[2212 센서](https://www.acmicpc.net/problem/2212)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

설명을 제대로 안해줘서 문제 이해가 헷갈렸다. 최대한 센서 사이의 거리를 띄어서 집중국을 설치할 수 있는 갯수를 구하면 된다.

### 풀이 도출 과정

먼저 센서를 정렬하고 센서 사이의 거리를 배열에 담아 정렬한다. 

그리고 거기서 거리가 긴 상위 k-1개의 거리를 제외한 나머지 배열 값들의 합이 정답이다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

중간에 정렬이 담겨있기 때문에

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="860" alt="Screenshot 2024-12-14 at 5 07 55 PM" src="https://github.com/user-attachments/assets/f33b4249-f7e0-41be-a211-126bde7090bc" />
