### PR TITLE
강두오 10일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_31963/Main.java
+++ b/duoh/ALGO/src/boj_31963/Main.java
@@ -1,0 +1,52 @@
+package boj_31963;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int N = Integer.parseInt(br.readLine());
+		int[] A = new int[N];
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++)
+			A[i] = Integer.parseInt(st.nextToken());
+
+		int[] next = new int[N];
+		for (int i = 1; i < N - 1; i++) {
+			int tmp = A[i];
+
+			while (tmp <= A[i + 1]) {
+				tmp <<= 1;
+				next[i]++;
+			}
+
+			if (next[i] > 0)
+				next[i]--;
+		}
+
+		int[] prev = new int[N + 1];
+		for (int i = 1; i < N; i++) {
+			int tmp = A[i];
+
+			while (tmp < A[i - 1]) {
+				tmp <<= 1;
+				prev[i]++;
+			}
+
+			if (next[i] < prev[i])
+				prev[i + 1] += prev[i] - next[i];
+		}
+
+		long count = 0L;
+		for (int p : prev)
+			count += p;
+
+		System.out.println(count - prev[N]);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[31963 두 배](https://www.acmicpc.net/problem/31963)

## 풀이

### 풀이에 대한 직관적인 설명

수열 A를 오름차순으로 만들기 위한 두 배 연산 횟수를 구하는 문제이다.

### 풀이 도출 과정

- 뒤 숫자와 비교
  - `A[i] <= A[i + 1]` 이면 두 배 연산하고 `next[i]++`
  - 불필요한 연산 보정을 위해 마지막에 `next[i]--`
  
- 앞 숫자와 비교
  - `A[i] < A[i - 1]` 이면 두 배 연산하고 `prev[i]++`
  - `next[i] < prev[i]` 이면 초과된 연산을 다음 위치 `prev[i + 1]`에 넘김
  
- `prev` 배열의 마지막 값을 제외한 모든 값을 합산 `(long 타입 사용해야됨)`

> 아이디어는 단순한데, 시간복잡도 개선이 어려웠다..
로그를 이용해서 쉽게 풀이할 수 있더라..

## 복잡도

* 시간복잡도: O(N)
배열을 두 번 순회하면서 뒤와 앞 숫자를 비교하는 연산 수행

## 채점 결과
<img width="938" alt="스크린샷 2024-12-17 오후 2 14 31" src="https://github.com/user-attachments/assets/becc0824-1fe2-453c-9090-402a431eb0d2" />