### PR TITLE
오동재 9일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_1026/Main.java
+++ b/dongjae/ALGO/src/boj_1026/Main.java
@@ -1,0 +1,38 @@
+package boj_1026;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n;
+    public static ArrayList<Integer> A = new ArrayList<>();
+    public static ArrayList<Integer> B = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            A.add(Integer.parseInt(st.nextToken()));
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            B.add(Integer.parseInt(st.nextToken()));
+        }
+
+        Collections.sort(A);
+        Collections.sort(B, Collections.reverseOrder());
+
+        System.out.println(function());
+    }
+
+    public static int function() {
+        int result = 0;
+        for (int i = 0; i < n; i++) {
+            result += A.get(i) * B.get(i);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## 문제

[1026 보물](https://www.acmicpc.net/problem/1026)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

결과값을 정답으로 원하기 때문에 문제 풀이 과정에 상관 없이 항상 작은 값만을 구하면 된다.

### 풀이 도출 과정

A만을 정렬하든, B만을 정렬하든, A와 B를 둘 다 정렬하든 결과는 모두 같다. 

따라서 A의 가장 작은 값이 B의 가장 큰 값과 매칭되도록 두 배열을 정렬하면 된다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

정렬에 소요되는 시간복잡도가 가장 크다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="857" alt="Screenshot 2024-12-18 at 3 01 27 PM" src="https://github.com/user-attachments/assets/d93860ba-862b-4d69-99cf-df7bfe843d0f" />
