### PR TITLE
오동재 11일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_4889/Main.java
+++ b/dongjae/ALGO/src/boj_4889/Main.java
@@ -1,0 +1,49 @@
+package boj_4889;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int count = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        while (true) {
+            String str = br.readLine();
+            if (str.contains("-")) {
+                break;
+            }
+            count++;
+
+            // 사전 준비
+            int change = 0;
+            Stack<Character> stack = new Stack<>();
+
+            // 본 게임
+            for (int i = 0; i < str.length(); i++) {
+                char now = str.charAt(i);
+                if (now == '{') {
+                    stack.push('{');
+                } else {
+                    if (!stack.isEmpty()) {
+                        stack.pop();
+                    } else {
+                        change++;
+                        stack.push('{');
+                    }
+                }
+            }
+
+            if (!stack.isEmpty()) {
+                change += stack.size() / 2;
+            }
+
+            sb.append(count).append(". ");
+            sb.append(change).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 문제

[4889 안정적인 문자열](https://www.acmicpc.net/problem/4889)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

여는 괄호는 스택에 넣고 닫는 괄호는 스택이 비어있지 않을 때만 스택을 팝한다.

### 풀이 도출 과정

다만 다음 두가지 예외를 고려한다.

* 닫는 괄호가 스택이 비어있는 상태에서 등장할 시 pop 대신 여는 괄호를 push하고 정답 + 1 한다.
* 문자열을 모두 순회하였음에도 스택이 남아있다면 남아있는 스택의 사이즈 / 2 를 정답 값으로 추가한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(T * n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

각 테스트 케이스마다 문자열을 순회하므로

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="707" alt="Screenshot 2024-12-19 at 3 53 07 PM" src="https://github.com/user-attachments/assets/2edef099-6bc0-4b6e-9a76-7fa4f418f014" />
