### PR TITLE
강두오 11일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_15828/Main.java
+++ b/duoh/ALGO/src/boj_15828/Main.java
@@ -1,0 +1,35 @@
+package boj_15828;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		Deque<Integer> q = new ArrayDeque<>();
+		int N = Integer.parseInt(br.readLine());
+
+		while (true) {
+			int v = Integer.parseInt(br.readLine());
+			if (v == -1) break;
+
+			if (v == 0) {
+				q.pollFirst();
+			} else if (q.size() < N) {
+				q.offer(v);
+			}
+		}
+
+		StringBuilder sb = new StringBuilder();
+		while (!q.isEmpty()) {
+			sb.append(q.pollFirst()).append(' ');
+		}
+
+		System.out.println(sb.isEmpty() ? "empty" : sb);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[15828 Router](https://www.acmicpc.net/problem/15828)

## 풀이

### 풀이에 대한 직관적인 설명

제한된 크기의 라우터 버퍼에서 입력 패킷을 처리하는 문제이다.

### 풀이 도출 과정

- 입력 패킷 처리
  - `-1`이면 입력 종료,`0`이면 가장 오래된 패킷 제거
  - 버퍼가 꽉 차면 버림
- 버퍼가 비어있으면 "empty", 아니면 남은 패킷 출력

## 복잡도

* 시간복잡도: O(N)

입력 패킷 수에 비례함

## 채점 결과
<img width="938" alt="스크린샷 2024-12-19 오후 6 15 40" src="https://github.com/user-attachments/assets/12ef71f6-8dd9-4dc4-b5bb-79d8a706441e" />

> StringBuilder의 `isEmpty()` 메서드는 Java 15부터 지원하기에, Java 11 제출 시 `sb.length() == 0`을 사용해야됨