### PR TITLE
강두오 12일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_13334/Main.java
+++ b/duoh/ALGO/src/boj_13334/Main.java
@@ -1,0 +1,46 @@
+package boj_13334;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int n = Integer.parseInt(br.readLine());
+		List<int[]> list = new ArrayList<>();
+
+		for (int i = 0; i < n; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int h = Integer.parseInt(st.nextToken());
+			int o = Integer.parseInt(st.nextToken());
+			list.add(new int[] {Math.min(h, o), Math.max(h, o)});
+		}
+
+		int d = Integer.parseInt(br.readLine());
+		list.sort(Comparator.comparingInt(a -> a[1]));
+
+		int count = 0;
+		PriorityQueue<Integer> pq = new PriorityQueue<>();
+
+		for (int[] li : list) {
+			if (li[1] - li[0] > d)
+				continue;
+
+			pq.offer(li[0]);
+			while (!pq.isEmpty() && pq.peek() < li[1] - d) {
+				pq.poll();
+			}
+			count = Math.max(count, pq.size());
+		}
+
+		System.out.println(count);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[13334 철로](https://www.acmicpc.net/problem/13334)

## 풀이

### 풀이에 대한 직관적인 설명

철로 길이 내에서 최대한 많은 구간이 포함되도록 하는 문제이다. 

### 풀이 도출 과정

- 최소/최대값으로 리스트에 저장하고, 최대값 기준 정렬
- 리스트 순회
  - 구간이 철로 길이보다 크면 제외, 아니라면 최소값을 우선순위 큐에 추가
  - 큐에서 철로 길이 내 범위를 벗어난 최소값 제거
  - 최대값 갱신

## 복잡도

* 시간복잡도: O(n log n)

정렬, 우선순위 큐 모두 O(n log n)

## 채점 결과
<img width="940" alt="스크린샷 2024-12-20 오후 5 31 20" src="https://github.com/user-attachments/assets/af454311-2bb6-4760-814d-23a5f0c21b38" />
