### PR TITLE
강두오 13일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_22866/Main.java
+++ b/duoh/ALGO/src/boj_22866/Main.java
@@ -1,0 +1,73 @@
+package boj_22866;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int N = Integer.parseInt(br.readLine());
+		int[] height = new int[N + 1];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		for (int i = 1; i <= N; i++) {
+			height[i] = Integer.parseInt(st.nextToken());
+		}
+
+		int[] leftCnt = new int[N + 1];
+		int[] leftNear = new int[N + 1];
+		Deque<Integer> stack = new ArrayDeque<>();
+
+		for (int i = 1; i <= N; i++) {
+			while (!stack.isEmpty() && height[stack.peek()] <= height[i]) {
+				stack.pop();
+			}
+
+			leftCnt[i] = stack.size();
+			leftNear[i] = stack.isEmpty() ? 0 : stack.peek();
+			stack.push(i);
+		}
+
+		int[] rightCnt = new int[N + 1];
+		int[] rightNear = new int[N + 1];
+		stack.clear();
+
+		for (int i = N; i >= 1; i--) {
+			while (!stack.isEmpty() && height[stack.peek()] <= height[i]) {
+				stack.pop();
+			}
+
+			rightCnt[i] = stack.size();
+			rightNear[i] = stack.isEmpty() ? 0 : stack.peek();
+			stack.push(i);
+		}
+
+		StringBuilder sb = new StringBuilder();
+		for (int i = 1; i <= N; i++) {
+			int total = leftCnt[i] + rightCnt[i];
+
+			if (total == 0) {
+				sb.append(0);
+			} else {
+				sb.append(total).append(' ');
+
+				if (leftNear[i] == 0) {
+					sb.append(rightNear[i]);
+				} else if (rightNear[i] == 0) {
+					sb.append(leftNear[i]);
+				} else {
+					sb.append(i - leftNear[i] <= rightNear[i] - i ? leftNear[i] : rightNear[i]);
+				}
+			}
+			sb.append('\n');
+		}
+
+		System.out.println(sb);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[22866 탑 보기](https://www.acmicpc.net/problem/22866)

## 풀이

### 풀이에 대한 직관적인 설명

각 건물에서 볼 수 있는 건물의 개수를 출력하는 문제이다.
단, 볼 수 있는 건물의 개수가 1개 이상이라면 거리가 가장 가까운 건물 번호 중 작은 번호를 출력한다.

### 풀이 도출 과정

- 모노톤 스택을 활용하여 왼쪽 -> 오른쪽, 오른쪽 -> 왼쪽 계산
  - 현재 건물보다 낮은 건물은 스택에서 제거
  - 스택 크기가 볼 수 있는 건물 수이고, top이 가장 가까운 건물임
- 합산
  - 왼쪽 + 오른쪽 결과로 볼 수 있는 건물이 없으면 0, 있으면 거리 비교 후 선택

## 복잡도

* 시간복잡도: O(N)

왼쪽, 오른쪽 계산 모두 O(N) 소요됨

## 채점 결과
<img width="937" alt="스크린샷 2024-12-22 오후 5 36 26" src="https://github.com/user-attachments/assets/d101187c-0b59-44ec-a9aa-63ea6105a667" />
