### PR TITLE
김신희 11일차 문제 풀이

### DIFF
--- a/shinhee/ALGO/src/boj_1764/Main.java
+++ b/shinhee/ALGO/src/boj_1764/Main.java
@@ -1,0 +1,39 @@
+package ALGO.src.boj_1764;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        HashSet<String> set = new HashSet<>();
+        for (int i = 0; i < N; i++) {
+            set.add(br.readLine());
+        }
+
+        ArrayList<String> result = new ArrayList<>();
+        for (int i = 0; i < M; i++) {
+            String tmp = br.readLine();
+            if(set.contains(tmp)){
+                result.add(tmp);
+            }
+        }
+
+        Collections.sort(result);
+
+        System.out.println(result.size());
+        for (String s : result) {
+            System.out.println(s);
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[1764 듣보잡](https://www.acmicpc.net/problem/1764)

## 풀이

### 풀이에 대한 직관적인 설명
두 집합 간의 교집합을 구하고 사전순으로 정렬하는 작업
### 풀이 도출 과정
`HashSet`을 사용항 듣도 못한 사람 목록을 저장, 듣도 못한 사람 목록에 포함되어있으면 이름을 결과 리스트에 추가한 후 사전 순으로 정렬

## 복잡도

* 시간복잡도: `O(n log n)`

## 채점 결과

![image](https://github.com/user-attachments/assets/70a3871b-f46a-4fea-8f66-c5488840a2ee)