### PR TITLE
강두오 14일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_15500/Main.java
+++ b/duoh/ALGO/src/boj_15500/Main.java
@@ -1,0 +1,62 @@
+package boj_15500;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+public class Main {
+	private static final StringBuilder sb = new StringBuilder();
+	private static int K = 0;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int N = Integer.parseInt(br.readLine());
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		Deque<Integer> stack1 = new ArrayDeque<>();
+		Deque<Integer> stack2 = new ArrayDeque<>();
+
+		for (int i = 0; i < N; i++) {
+			stack1.push(Integer.parseInt(st.nextToken()));
+		}
+
+		int[] disk = new int[N + 1];
+		for (int i = 1; i <= N; i++) {
+			disk[i] = 1;
+		}
+
+		do {
+			if (disk[N] == 1) {
+				while (stack1.peek() != N) {
+					int v = stack1.pop();
+					stack2.push(v);
+					disk[v] = 2;
+					move(1, 2);
+				}
+				stack1.pop();
+				move(1, 3);
+			} else if (disk[N] == 2) {
+				while (stack2.peek() != N) {
+					int v = stack2.pop();
+					stack1.push(v);
+					disk[v] = 1;
+					move(2, 1);
+				}
+				stack2.pop();
+				move(2, 3);
+			}
+		} while (N-- > 0);
+
+		System.out.println(K);
+		System.out.println(sb);
+		br.close();
+	}
+
+	private static void move(int A, int B) {
+		sb.append(A).append(' ').append(B).append('\n');
+		K++;
+	}
+}


### PR DESCRIPTION
## 문제

[15500 이상한 하노이 탑](https://www.acmicpc.net/problem/15500)

## 풀이

### 풀이에 대한 직관적인 설명

기존 하노이 탑 문제를 약간 변형한 문제이다.
> 원판 순서 조건 삭제, 첫 번째 장대에 무작위 원판 배치

### 풀이 도출 과정

- `stack1, stack2`와 원판 위치를 저장할 `disk` 배열 선언
- 조건에 따라 시뮬레이션

## 복잡도

* 시간복잡도: O(N)

각 원판 이동

## 채점 결과
<img width="937" alt="스크린샷 2024-12-24 오전 9 59 30" src="https://github.com/user-attachments/assets/16502644-7031-4460-abc5-f38f4d386a6a" />