### PR TITLE
강두오 15일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_31719/Main.java
+++ b/duoh/ALGO/src/boj_31719/Main.java
@@ -1,0 +1,57 @@
+package boj_31719;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringBuilder sb = new StringBuilder();
+		int T = Integer.parseInt(br.readLine());
+
+		while (T-- > 0) {
+			int N = Integer.parseInt(br.readLine());
+			StringTokenizer st = new StringTokenizer(br.readLine());
+
+			int last = 0, dTop = 0, dBottom = 0, pTop = 0, pBottom = 0;
+			boolean flag = false;
+
+			while (N-- > 0) {
+				int v = Integer.parseInt(st.nextToken());
+
+				if (dBottom == last + 1) {
+					last = dTop;
+					dBottom = dTop = 0;
+				}
+
+				if (pBottom == last + 1) {
+					last = pTop;
+					pBottom = pTop = 0;
+				}
+
+				if (v == last + 1) {
+					last++;
+				} else if (v == dTop + 1) {
+					dTop++;
+				} else if (v == pTop + 1) {
+					pTop++;
+				} else if (dBottom == 0) {
+					dBottom = dTop = v;
+				} else if (pBottom == 0) {
+					pBottom = pTop = v;
+				} else {
+					flag = true;
+					break;
+				}
+			}
+
+			sb.append(flag ? "NO" : "YES").append('\n');
+		}
+
+		System.out.println(sb);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[31719 UDP 스택](https://www.acmicpc.net/problem/31719)

## 풀이

### 풀이에 대한 직관적인 설명

순열 A를 오름차순으로 재배열로 할 수 있는지 판별하는 문제이다.

### 풀이 도출 과정

- 처리 가능한 스택(D / P)이 있으면 `last`를 업데이트하고 스택 초기화
- 현재 숫자가 `last + 1`이거나, 스택의 탑 + 1이면 처리하거나 확장
- 비어있는 스택이 있으면 초기화
- 위 조건을 모두 만족하지 않으면 "NO"

## 복잡도

* 시간복잡도: O(N)

각 숫자를 한 번씩 처리

## 채점 결과
<img width="936" alt="스크린샷 2024-12-25 오전 10 08 04" src="https://github.com/user-attachments/assets/5b850d12-e2cb-4ebd-ab5d-858335cebdf3" />

> 문제 제목 때문에 삽질을 꽤했다..