### PR TITLE
오동재 16일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_2206/Main.java
+++ b/dongjae/ALGO/src/boj_2206/Main.java
@@ -1,0 +1,93 @@
+package boj_2206;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    private int x;
+    private int y;
+    private int broken;
+
+    public Node(int x, int y, int broken) {
+        this.x = x;
+        this.y = y;
+        this.broken = broken;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public int getY() {
+        return this.y;
+    }
+
+    public int getBroken() {
+        return this.broken;
+    }
+}
+
+public class Main {
+    public static int n, m;
+    public static int[][] map;
+    public static boolean[][][] visited;
+    public static int[][][] distance;
+    public static int[] dx = {-1, 0, 1, 0};
+    public static int[] dy = {0, -1, 0, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        map = new int[n+1][m+1];
+        visited = new boolean[2][n+1][m+1];
+        distance = new int[2][n+1][m+1];
+
+        for (int i = 1; i <= n; i++) {
+            String str = br.readLine();
+            for (int j = 1; j <= m; j++) {
+                map[i][j] = str.charAt(j - 1) - '0';
+            }
+        }
+
+        int result = bfs(new Node(1, 1, 0));
+
+        System.out.println(result == Integer.MAX_VALUE ? "-1" : result);
+    }
+
+    public static int bfs(Node start) {
+        Queue<Node> q = new LinkedList<>();
+        visited[start.getBroken()][start.getX()][start.getY()] = true;
+        distance[start.getBroken()][start.getX()][start.getY()] = 1;
+        q.offer(start);
+        while (!q.isEmpty()) {
+            Node now = q.poll();
+            if (now.getX() == n && now.getY() == m) {
+                return distance[now.getBroken()][now.getX()][now.getY()];
+            }
+
+            for (int i = 0; i < 4; i++) {
+                int nx = now.getX() + dx[i];
+                int ny = now.getY() + dy[i];
+                int broken = now.getBroken();
+                if (nx > 0 && ny > 0 && nx <= n && ny <= m) {
+                    if (map[nx][ny] == 0 && !visited[broken][nx][ny]) {
+                        visited[broken][nx][ny] = true;
+                        distance[broken][nx][ny] = distance[broken][now.getX()][now.getY()] + 1;
+                        q.offer(new Node(nx, ny, broken));
+                    }
+
+                    if (map[nx][ny] == 1 && broken == 0 && !visited[broken][nx][ny]) {
+                        visited[1][nx][ny] = true;
+                        distance[1][nx][ny] = distance[broken][now.getX()][now.getY()] + 1;
+                        q.offer(new Node(nx, ny, 1));
+                    }
+                }
+            }
+        }
+        return Integer.MAX_VALUE;
+    }
+}


### PR DESCRIPTION
## 문제

[2206 벽 부수고 이동하기](https://www.acmicpc.net/problem/2206)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

벽을 부수는게 가능한 BFS 문제이다.

### 풀이 도출 과정

단순히 벽을 부수는 경우와 부수지 않는 경우로 계산하면 시간 초과가 발생한다.

이를 해결하기 위해서는 경우를 나눈다기 보다 한 번에 BFS를 처리해야 한다.

* visited 배열과 distance 배열을 3차원으로 구성한다.
* 일반적인 경우와 같이 탐색을 실시하되 매 경로마다 벽을 하나씩 부순다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(N * M)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

맵을 완전탐색하는 시간만큼

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="858" alt="Screenshot 2024-12-26 at 4 43 38 PM" src="https://github.com/user-attachments/assets/9abf61db-e879-4447-8152-2c9faf525198" />