### PR TITLE
안준영 16일차 문제 풀이

### DIFF
--- a/junyeong/src/boj_1260/Main.java
+++ b/junyeong/src/boj_1260/Main.java
@@ -1,0 +1,77 @@
+package boj_1260;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static List<Integer>[] graph;
+    static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int v = Integer.parseInt(st.nextToken());
+
+        graph = new ArrayList[n + 1];
+        for (int i = 1; i <= n; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+
+        for (int i = 1; i <= n; i++) {
+            Collections.sort(graph[i]);
+        }
+
+        visited = new boolean[n + 1];
+        List<Integer> dfsResult = new ArrayList<>();
+        dfs(v, dfsResult);
+        System.out.println(String.join(" ", dfsResult.stream().map(String::valueOf).toArray(String[]::new)));
+
+        visited = new boolean[n + 1];
+        List<Integer> bfsResult = bfs(v);
+        System.out.println(String.join(" ", bfsResult.stream().map(String::valueOf).toArray(String[]::new)));
+    }
+
+    private static void dfs(int node, List<Integer> result) {
+        visited[node] = true;
+        result.add(node);
+
+        for (int neighbor : graph[node]) {
+            if (!visited[neighbor]) {
+                dfs(neighbor, result);
+            }
+        }
+    }
+
+    private static List<Integer> bfs(int start) {
+        Queue<Integer> queue = new LinkedList<>();
+        List<Integer> result = new ArrayList<>();
+
+        queue.add(start);
+        visited[start] = true;
+
+        while (!queue.isEmpty()) {
+            int node = queue.poll();
+            result.add(node);
+
+            for (int neighbor : graph[node]) {
+                if (!visited[neighbor]) {
+                    visited[neighbor] = true;
+                    queue.add(neighbor);
+                }
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## 문제

[1260 DFS와 BFS](https://www.acmicpc.net/problem/1260)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명
정점 번호가 작은 순서대로 탐색하고 DFS와 BFS의 탐색 결과를 출력한다.
탐색 시작점을 기준으로 도달 가능한 모든 정점을 방문

### 풀이 도출 과정
주어진 입력 데이터를 기반으로 정점과 간선을 인접 리스트 형태로 저장하고 각 정점의 연결 리스트를 정렬하여 탐색 시 정점 번호가 작은 순서대로 방문.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(V+E)
* 최대 정점의 개수를 V라 두고 최대 간선의 개수를 E라 두었을 때 그래프 탐색의 시간복잡도는 V+E이다.

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
![image](https://github.com/user-attachments/assets/f454c069-cdb5-4856-a95f-c5c2ed9d28eb)
