### PR TITLE
강두오 17일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_1325/Main.java
+++ b/duoh/ALGO/src/boj_1325/Main.java
@@ -1,0 +1,67 @@
+package boj_1325;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+	private static List<Integer>[] graph;
+	private static boolean[] visited;
+	private static int[] counter;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		graph = new ArrayList[N + 1];
+		counter = new int[N + 1];
+
+		for (int i = 1; i <= N; i++) {
+			graph[i] = new ArrayList<>();
+		}
+
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int A = Integer.parseInt(st.nextToken());
+			int B = Integer.parseInt(st.nextToken());
+			graph[B].add(A);
+		}
+
+		for (int i = 1; i <= N; i++) {
+			visited = new boolean[N + 1];
+			bfs(i);
+		}
+
+		int max = Arrays.stream(counter).max().orElse(0);
+		StringBuilder sb = new StringBuilder();
+		for (int i = 1; i <= N; i++) {
+			if (counter[i] == max) {
+				sb.append(i).append(' ');
+			}
+		}
+
+		System.out.println(sb);
+		br.close();
+	}
+
+	private static void bfs(int start) {
+		Deque<Integer> q = new ArrayDeque<>();
+		visited[start] = true;
+		q.offer(start);
+
+		while (!q.isEmpty()) {
+			int cur = q.poll();
+
+			for (int next : graph[cur]) {
+				if (!visited[next]) {
+					visited[next] = true;
+					counter[start]++;
+					q.offer(next);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 문제

[1325 효율적인 해킹](https://www.acmicpc.net/problem/1325)

## 풀이

### 풀이에 대한 직관적인 설명

한 번에 가장 많은 컴퓨터를 해킹할 수 있는 컴퓨터의 번호를 출력하는 문제이다.


### 풀이 도출 과정

- 그래프 역방향 구성
- 각 노드에서 bfs 탐색하여 해킹 가능한 컴퓨터 수 계산
- 최대 해킹 가능한 수인 노드들 출력

## 복잡도

* 시간복잡도: O(N * M)

`N`은 컴퓨터 수, `M`은 신뢰 관계 수이고, 각 노드에서 bfs 탐색

## 채점 결과
<img width="937" alt="스크린샷 2024-12-27 오전 9 52 03" src="https://github.com/user-attachments/assets/0c74bf29-fbc2-4dd2-a901-7d4089e8ff3c" />

> 자바로 풀기 매우 매우 매우.. 까다로운 문제다;