### PR TITLE
안준영 17일차 문제 풀이

### DIFF
--- a/junyeong/src/boj_9372/Main.java
+++ b/junyeong/src/boj_9372/Main.java
@@ -1,0 +1,29 @@
+package boj_9372;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder result = new StringBuilder();
+
+        int t = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < t; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int n = Integer.parseInt(st.nextToken());
+            int m = Integer.parseInt(st.nextToken());
+
+            for (int j = 0; j < m; j++) {
+                br.readLine();
+            }
+
+            result.append(n - 1).append("\n");
+        }
+
+        System.out.print(result);
+    }
+}


### PR DESCRIPTION
## 문제

[9372 상근이의 여행](https://www.acmicpc.net/problem/9372)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명
모든 국가(노드)를 연결하기 위해 필요한 최소한의 비행기 종류(간선) 개수를 구한다.
### 풀이 도출 과정
국가를 그래프의 노드로 생각하고, 비행기를 그래프의 간선으로 생각한다. 모든 노드가 연결된 그래프를 만드는 데 필요한 최소 간선 개수를 구한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(T+M)
* T는 테스트의 수, M은 비행기의 수라 하고 그에 따라 비례하기 때문에

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
![image](https://github.com/user-attachments/assets/0fa1922b-5c08-4da2-82d0-a9cf78d5ebce)
