### PR TITLE
오동재 18일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_1707/Main.java
+++ b/dongjae/ALGO/src/boj_1707/Main.java
@@ -1,0 +1,66 @@
+package boj_1707;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int k;
+    public static int v, e;
+    public static ArrayList<ArrayList<Integer>> graph;
+    public static int[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        k = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < k; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            v = Integer.parseInt(st.nextToken());
+            e = Integer.parseInt(st.nextToken());
+
+            // 그래프 초기화
+            visited = new int[v+1];
+            graph = new ArrayList<>();
+            for (int j = 0; j <= v; j++) {
+                graph.add(new ArrayList<>());
+            }
+
+            for (int l = 0; l < e; l++) {
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+                graph.get(a).add(b);
+                graph.get(b).add(a);
+            }
+
+            if (bfs()) sb.append("YES").append("\n");
+            else sb.append("NO").append("\n");
+        }
+
+        System.out.println(sb);
+    }
+
+    public static boolean bfs() {
+        Queue<Integer> q = new LinkedList<>();
+        for (int i = 1; i <= v; i++) {
+            if (visited[i] == 0) {
+                q.offer(i);
+                visited[i] = 1;
+                while (!q.isEmpty()) {
+                    int now = q.poll();
+                    for (int next : graph.get(now)) {
+                        if (visited[next] == 0) {
+                            visited[next] = (visited[now] == 1) ? 2 : 1;
+                            q.offer(next);
+                        } else if (visited[next] == visited[now]) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
## 문제

[1707 이분 그래프](https://www.acmicpc.net/problem/1707)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

이분 그래프에 대한 개념을 파악하고 bfs로 3가지 종류의 방문처리를 해주는 것이 핵심

### 풀이 도출 과정

이분 그래프란 한 정점에서부터 1번과 2번 두 가지 번호를 부여하며 탐색을 시작할 때 마지막에 모두 인접한 정점끼리는 서로 다른 색을 지니고 있는 그래프를 말한다. 즉 "퐁당퐁당"이 되는 그래프.

* `visited` 배열을 단순히 `boolean`으로 방문을 했는지 안했는지로 구분하는 것이 아닌, `방문하지 않음`, `1번`, `2번` 3가지 경우로 나누어 저장한다.
* 완전탐색을 진행하며 현재 정점의 인접한 정점 중 방문을 했으면서 번호가 같은 정점이 있으면 거짓을 반환한다.

> 이분 그래프가 어떤 그래프인지만 파악하면 문제 풀이 자체는 쉽다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->

그래프 완전 탐색

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="859" alt="Screenshot 2024-12-31 at 6 23 45 PM" src="https://github.com/user-attachments/assets/7fa49d63-8c0c-46e8-aa8d-0fb78199ca03" />