### PR TITLE
오동재 20일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_2512/Main.java
+++ b/dongjae/ALGO/src/boj_2512/Main.java
@@ -1,0 +1,48 @@
+package boj_2512;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n;
+    public static ArrayList<Integer> nlist = new ArrayList<>();
+    public static long m;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            nlist.add(Integer.parseInt(st.nextToken()));
+        }
+
+        m = Integer.parseInt(br.readLine());
+
+        Collections.sort(nlist);
+
+        int result = binarySearch(1, nlist.get(nlist.size() - 1));
+        System.out.println(result);
+    }
+
+    public static int binarySearch(int start, int end) {
+        if (start > end) {
+            return end;
+        }
+        int mid = (start + end) / 2;
+        if (check(mid) > m) {
+            return binarySearch(start, mid - 1);
+        } else {
+            return binarySearch(mid + 1, end);
+        }
+    }
+
+    public static long check(int limit) {
+        long sum = 0;
+        for (int i = 0; i < nlist.size(); i++) {
+            if (limit > nlist.get(i)) sum += nlist.get(i);
+            else sum += limit;
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
## 문제

[2512 예산](https://www.acmicpc.net/problem/2512)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

파라메트릭 서치

### 풀이 도출 과정

이진탐색과 개념은 비슷하지만 경계선에 있는 값을 찾아야 하는 문제이다. 범위 특히 어떤 부분에서 start와 end 중 경계값을 반환하는지 잘 파악해야 한다.
> 이번 문제의 경우 탐색 범위를 예산의 최솟값에서 최댓값 사이 중에서 상한선을 결정하려했으나, 이는 상한선이 예산의 최솟값보다 작을 수 있는 경우를 고려하지 못한 설정으로 범위를 다시 조정해서 풀어주었다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

탐색 범위에 대한 이진 탐색 O(logn)과 check 함수 O(n)의 곱. 정렬은 파라메트릭 서치에서 사실 필요가 없다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

![Screenshot 2025-01-01 at 9 56 56 PM](https://github.com/user-attachments/assets/7bab3e1e-af3e-49ee-8001-421b56fde82f)
