### PR TITLE
강두오 21일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_12015/Main.java
+++ b/duoh/ALGO/src/boj_12015/Main.java
@@ -1,0 +1,54 @@
+package boj_12015;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+	private static List<Integer> lis;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int N = Integer.parseInt(br.readLine());
+		int[] A = new int[N];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		for (int i = 0; i < N; i++) {
+			A[i] = Integer.parseInt(st.nextToken());
+		}
+
+		lis = new ArrayList<>();
+		lis.add(A[0]);
+
+		for (int i = 1; i < N; i++) {
+			if (lis.get(lis.size() - 1) < A[i]) {
+				lis.add(A[i]);
+			} else {
+				binarySearch(A[i]);
+			}
+		}
+
+		System.out.println(lis.size());
+		br.close();
+	}
+
+	private static void binarySearch(int val) {
+		int low = 0, high = lis.size() - 1;
+
+		while (low < high) {
+			int mid = (low + high) / 2;
+
+			if (lis.get(mid) < val) {
+				low = mid + 1;
+			} else {
+				high = mid;
+			}
+		}
+
+		lis.set(high, val);
+	}
+}


### PR DESCRIPTION
## 문제

[12015 가장 긴 증가하는 부분 수열 2](https://www.acmicpc.net/problem/12015)

## 풀이

### 풀이에 대한 직관적인 설명

수열 A에서 가장 긴 증가하는 부분 수열을 구하는 문제이다.

### 풀이 도출 과정

- LIS를 저장할 리스트 선언
- 수열 순회
  - 현재 값이 LIS의 마지막 값보다 크면 추가
  - 아니라면 이분 탐색으로 위치를 찾아 갱신
- 최종 LIS 크기 출력

## 복잡도

* 시간복잡도: O(N log N)

수열의 길이는 N이고, 각 원소에 대해 이분 탐색

## 채점 결과
<img width="937" alt="스크린샷 2025-01-02 오전 11 26 44" src="https://github.com/user-attachments/assets/ba96595e-43fa-4e97-8165-8e8f6a48df81" />