### PR TITLE
오동재 21일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_2343/Main.java
+++ b/dongjae/ALGO/src/boj_2343/Main.java
@@ -1,0 +1,62 @@
+package boj_2343;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n, m;
+    public static int[] array;
+    public static int max;
+    public static long sum;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        array = new int[n];
+
+        max = 0;
+        sum = 0L;
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int now = Integer.parseInt(st.nextToken());
+            array[i] = now;
+            max = Math.max(now, max);
+            sum += now;
+        }
+
+        System.out.println(binarySearch(max, sum));
+    }
+
+    public static long binarySearch(long start, long end) {
+        while (start <= end) {
+            long mid = (start + end) / 2;
+            if (check(mid) > m) {
+                start = mid + 1;
+            } else {
+                end = mid - 1;
+            }
+        }
+        return start;
+    }
+
+    public static int check(long x) {
+        int count = 0;
+        long subSum = 0;
+        for (int i = 0; i < n; i++) {
+            subSum += array[i];
+            if (subSum > x) {
+                subSum = array[i];
+                count++;
+            } else if (subSum == x) {
+                subSum = 0;
+                count++;
+            }
+        }
+        if (subSum != 0) count++;
+        return count;
+    }
+}


### PR DESCRIPTION
## 문제

[2343 기타 레슨](https://www.acmicpc.net/problem/2343)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

파라메트릭 서치

### 풀이 도출 과정

* 이진탐색의 시작은 영상 배열의 최대값, 끝은 합계
* 이 사이에서 블루레이 영상 길이를 조절하며 영상 개수 m을 만족하는 블루레이 영상 길이의 최솟값을 구해준다
> 가장 헷갈리는 거는 이진 탐색이 끝났을 때 반환해야하는 값이 start인지 end인지... 하나씩 생각해봐야 알 수 있다. 좀 더 쉬운 공식 같은 건 없을까

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

이진 탐색에 걸리는 시간 O(logn) 매 mid 값 마다 영상 개수를 세는 데 걸리는 시간 O(n)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="858" alt="Screenshot 2025-01-02 at 10 42 47 PM" src="https://github.com/user-attachments/assets/a81d104f-4cd3-4b3e-9ced-c2b470ed4f88" />
