### PR TITLE
강두오 22일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_1477/Main.java
+++ b/duoh/ALGO/src/boj_1477/Main.java
@@ -1,0 +1,59 @@
+package boj_1477;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+	private static List<Integer> list;
+	private static int M;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		int L = Integer.parseInt(st.nextToken());
+
+		list = new ArrayList<>();
+		list.add(0);
+		list.add(L);
+
+		if (N > 0) {
+			st = new StringTokenizer(br.readLine());
+
+			for (int i = 0; i < N; i++) {
+				list.add(Integer.parseInt(st.nextToken()));
+			}
+		}
+
+		Collections.sort(list);
+		System.out.println(binarySearch(1, L - 1));
+		br.close();
+	}
+
+	private static int binarySearch(int left, int right) {
+		while (left <= right) {
+			int mid = (left + right) / 2;
+			int cnt = 0;
+
+			for (int i = 1; i < list.size(); i++) {
+				cnt += (list.get(i) - list.get(i - 1) - 1) / mid;
+			}
+
+			if (cnt > M) {
+				left = mid + 1;
+			} else {
+				right = mid - 1;
+			}
+		}
+
+		return left;
+	}
+}
+


### PR DESCRIPTION
## 문제

[1477 휴게소 세우기](https://www.acmicpc.net/problem/1477)

## 풀이

### 풀이에 대한 직관적인 설명

휴게소가 없는 구간의 길이 최댓값을 최소로 하는 문제이다.

### 풀이 도출 과정

- 휴게소 위치 정렬하고, 시작점(0)과 끝점(L) 추가
- 이분 탐색
  - `mid` 기준으로 각 구간에서 필요한 휴게소 개수 카운트
  - 필요한 휴게소 개수가 `M`보다 많으면 `mid` 증가, 적으면 감소

## 복잡도

* 시간복잡도: O(N log L)

정렬하고, 이분 탐색

## 채점 결과
<img width="936" alt="스크린샷 2025-01-03 오후 9 15 41" src="https://github.com/user-attachments/assets/d0a8771d-8226-40e5-b7a4-5b0938adb878" />