### PR TITLE
김신희 21일차 문제 풀이

### DIFF
--- a/shinhee/ALGO/src/boj_24479/Main.java
+++ b/shinhee/ALGO/src/boj_24479/Main.java
@@ -1,0 +1,65 @@
+package ALGO.src.boj_24479;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    static ArrayList<ArrayList<Integer>> graph = new ArrayList<>();
+    static int[] visited;
+    static int count;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        st = new StringTokenizer(br.readLine());
+
+        int vertex = Integer.parseInt(st.nextToken());
+        int edge = Integer.parseInt(st.nextToken());
+        int start = Integer.parseInt(st.nextToken());
+
+        visited = new int[vertex+1];
+
+        for(int i =0; i < vertex+1; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for(int i = 0; i < edge; i++) {
+            st = new StringTokenizer(br.readLine());
+            int fromVertex = Integer.parseInt(st.nextToken());
+            int toVertex = Integer.parseInt(st.nextToken());
+
+            graph.get(fromVertex).add(toVertex);
+            graph.get(toVertex).add(fromVertex);
+        }
+
+        for(int i = 1; i < graph.size(); i++) {
+            Collections.sort(graph.get(i));
+        }
+
+        count = 1;
+
+        dfs(start);
+
+        for(int i = 1; i < visited.length; i++) {
+            sb.append(visited[i]).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    private static void dfs(int vertex) {
+        visited[vertex] = count;
+
+        for(int i = 0; i < graph.get(vertex).size(); i++) {
+            int newVertex = graph.get(vertex).get(i);
+
+            if(visited[newVertex] == 0){
+                count++;
+                dfs(newVertex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[24479 알고리즘 수업 - 깊이 우선 탐색1](https://www.acmicpc.net/problem/24479 )

## 풀이

### 풀이에 대한 직관적인 설명
DFS
### 풀이 도출 과정
1. ArrayList로 인접 리스트 형태로 그래프를 초기화(각 정점에 연결된 정점을 추가)
2. 각 정점의 인접 리스트를 정렬, 정점 번호가 작은 것부터 방문
3. DFS진행. 방문한 정점은 visited 배열에 순서를 기록하고, 인접한 정점 중 아직 방문하지 않은 정점이 있으면 DFS 호출

## 복잡도

* 시간복잡도: O(V + E)
모든 정점(V)을 한 번씩 방문하고, 모든 간선(E)을 한 번씩 탐색하기 때문

## 채점 결과
![image](https://github.com/user-attachments/assets/d7bd04f6-2206-47b1-9380-9ecb8009198a)

