### PR TITLE
강두오 25일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_11266/Main.java
+++ b/duoh/ALGO/src/boj_11266/Main.java
@@ -1,0 +1,84 @@
+package boj_11266;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+	private static List<Integer>[] graph;
+	private static int[] discover;
+	private static boolean[] isCutV;
+	private static int order = 1;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int V = Integer.parseInt(st.nextToken());
+		int E = Integer.parseInt(st.nextToken());
+		graph = new ArrayList[V + 1];
+
+		for (int i = 1; i <= V; i++) {
+			graph[i] = new ArrayList<>();
+		}
+
+		for (int i = 0; i < E; i++) {
+			st = new StringTokenizer(br.readLine());
+			int A = Integer.parseInt(st.nextToken());
+			int B = Integer.parseInt(st.nextToken());
+			graph[A].add(B);
+			graph[B].add(A);
+		}
+
+		discover = new int[V + 1];
+		isCutV = new boolean[V + 1];
+
+		for (int i = 1; i <= V; i++) {
+			if (discover[i] == 0) {
+				dfs(i, true);
+			}
+		}
+
+		int cnt = 0;
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 1; i <= V; i++) {
+			if (isCutV[i]) {
+				cnt++;
+				sb.append(i).append(' ');
+			}
+		}
+
+		System.out.println(cnt + "\n" + sb);
+		br.close();
+	}
+
+	private static int dfs(int node, boolean isRoot) {
+		discover[node] = order++;
+		int lowest = discover[node];
+		int children = 0;
+
+		for (int next : graph[node]) {
+			if (discover[next] == 0) {
+				children++;
+				int low = dfs(next, false);
+
+				if (!isRoot && low >= discover[node]) {
+					isCutV[node] = true;
+				}
+				lowest = Math.min(lowest, low);
+			} else {
+				lowest = Math.min(lowest, discover[next]);
+			}
+		}
+
+		if (isRoot && children >= 2) {
+			isCutV[node] = true;
+		}
+
+		return lowest;
+	}
+}


### PR DESCRIPTION
## 문제

[11266 단절점](https://www.acmicpc.net/problem/11266)

## 풀이

### 풀이에 대한 직관적인 설명

단절점의 개수와 정점 번호를 오름차순으로 출력하는 문제이다.
> 그래프에서 특정 정점을 제거하였을 때, 연결 요소가 증가하는 정점을 단절점이라고 한다.

### 풀이 도출 과정

- dfs 탐색으로 각 정점의 방문 순서를 기록
- 서브트리의 가장 낮은 방문 순서를 비교해서 단절점 여부를 판단
  - 자식 노드의 가장 낮은 방문 순서가 현재 정점의 방문 순서 이상이면 단절점
  - 루트 정점의 경우, 자식 노드가 2개 이상이면 단절점

> 신기하고, 생각보다 구현이 어렵다..

## 복잡도

* 시간복잡도: O(V + E)

dfs로 모든 정점과 간선을 한 번씩 탐색

## 채점 결과
<img width="936" alt="스크린샷 2025-01-07 오후 12 37 33" src="https://github.com/user-attachments/assets/82bb2b15-428c-4103-9ff9-0ce666d142f9" />