### PR TITLE
오동재 22일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_1939/Main.java
+++ b/dongjae/ALGO/src/boj_1939/Main.java
@@ -1,0 +1,90 @@
+package boj_1939;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    private int destination;
+    private long distance;
+
+    public Node(int destination, long distance) {
+        this.destination = destination;
+        this.distance = distance;
+    }
+
+    public int getDestination() {
+        return this.destination;
+    }
+
+    public long getDistance() {
+        return this.distance;
+    }
+}
+
+public class Main {
+    public static int n, m;
+    public static ArrayList<ArrayList<Node>> graph = new ArrayList<>();
+    public static int from, to;
+    public static boolean[] visited;
+    public static long max = Long.MIN_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            long c = Long.parseLong(st.nextToken());
+
+            graph.get(a).add(new Node(b, c));
+            graph.get(b).add(new Node(a, c));
+
+            max = Math.max(c, max);
+        }
+
+        st = new StringTokenizer(br.readLine());
+        from = Integer.parseInt(st.nextToken());
+        to = Integer.parseInt(st.nextToken());
+
+        long answer = binarySearch(0, max);
+        System.out.println(answer);
+    }
+
+    public static boolean dfs(int now, long limit) {
+        visited[now] = true;
+        if (now == to) {
+            return true;
+        }
+        for (int i = 0; i < graph.get(now).size(); i++) {
+            Node next = graph.get(now).get(i);
+            if (!visited[next.getDestination()] && next.getDistance() >= limit) {
+                if(dfs(next.getDestination(), limit)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static long binarySearch(long start, long end) {
+        while (start <= end) {
+            long mid = (start + end) / 2;
+            visited = new boolean[n+1];
+            if (dfs(from, mid)) {
+                start = mid + 1;
+            } else {
+                end = mid - 1;
+            }
+        }
+        return end;
+    }
+}


### PR DESCRIPTION
## 문제

[1939 중량제한](https://www.acmicpc.net/problem/1939)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

DFS와 이분탐색을 결합한 문제

### 풀이 도출 과정

가능한 중량의 최댓값을 찾는 과정에서 조건 검사로 DFS가 사용된다. DFS를 이용해서 목적지까지 정해진 중량으로 통행이 가능한지 여부를 판단해야 한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

이진탐색을 수행하는데 O(logn)의 시간이 소요되고 DFS로 인해 일차원 배열의 값을 완전탐색하면 총 O(nlogn)의 시간이 소요된다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="858" alt="Screenshot 2025-01-07 at 5 13 30 PM" src="https://github.com/user-attachments/assets/f16d7c94-fcab-4b41-986f-990be056605d" />
