### PR TITLE
오동재 23일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_2644/Main.java
+++ b/dongjae/ALGO/src/boj_2644/Main.java
@@ -1,0 +1,57 @@
+package boj_2644;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n, m;
+    public static int t1, t2;
+    public static ArrayList<ArrayList<Integer>> graph = new ArrayList<>();
+    public static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        t1 = Integer.parseInt(st.nextToken());
+        t2 = Integer.parseInt(st.nextToken());
+
+        m = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        visited = new boolean[n+1];
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+
+            graph.get(x).add(y);
+            graph.get(y).add(x);
+        }
+
+        int answer = dfs(t1, t2, 0);
+        System.out.println(answer);
+    }
+
+    public static int dfs(int start, int end, int depth) {
+        visited[start] = true;
+        if (start == end) {
+            return depth;
+        }
+        for (int i = 0; i < graph.get(start).size(); i++) {
+            int next = graph.get(start).get(i);
+            if (!visited[next]) {
+                int result = dfs(next, end, depth + 1);
+                if (result != -1) {
+                    return result;
+                }
+            }
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
## 문제

[2644 촌수계산](https://www.acmicpc.net/problem/2644)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

DFS를 이용한 거리계산

### 풀이 도출 과정

* 재귀함수의 깊이에 따른 촌수를 반환한다.
* 유의할 부분은 분리 집합일 경우에 대한 처리, 즉 dfs로 접근할 수 없는 결과에 대해서는 -1을 명확히 반환해야 함.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->

주어진 두 명의 촌수 계산에 따른 완전탐색

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="857" alt="Screenshot 2025-01-07 at 6 06 02 PM" src="https://github.com/user-attachments/assets/5f47fa25-4a25-4648-b5b9-78a802e6e4ff" />
