### PR TITLE
안준영 23일차 문제 풀이

### DIFF
--- a/junyeong/src/boj_5576/Main.java
+++ b/junyeong/src/boj_5576/Main.java
@@ -1,0 +1,57 @@
+package boj_5576;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        int m = Integer.parseInt(br.readLine());
+
+        List<List<Integer>> graph = new ArrayList<>();
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < m; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph.get(a).add(b);
+            graph.get(b).add(a);
+        }
+
+        System.out.println(inviteCount(graph, n));
+    }
+
+    private static int inviteCount(List<List<Integer>> graph, int n) {
+        boolean[] visited = new boolean[n + 1];
+        Queue<Integer> queue = new LinkedList<>();
+
+        queue.add(1);
+        visited[1] = true;
+
+        int inviteCount = 0;
+        int depth = 0;
+
+        while (!queue.isEmpty() && depth < 2) {
+            int size = queue.size();
+            for (int i = 0; i < size; i++) {
+                int current = queue.poll();
+
+                for (int friend : graph.get(current)) {
+                    if (!visited[friend]) {
+                        visited[friend] = true;
+                        queue.add(friend);
+                        inviteCount++;
+                    }
+                }
+            }
+            depth++;
+        }
+
+        return inviteCount;
+    }
+}


### PR DESCRIPTION
## 문제

[5567 결혼식](https://www.acmicpc.net/problem/5567)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명
상근이의 친구와 친구의 친구를 BFS로 탐색하여 초대할 사람의 수를 계산한다

### 풀이 도출 과정
인접 리스트를 사용하여 친구관계를 표시하고 visited 배열로 중복 탐색을 방지한다. 반복문을 돌며 큐를 BFS탐색한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(N + M)
* 노드 방문에 O(N) + 간선 탐색 O(M)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
![image](https://github.com/user-attachments/assets/d61db60d-6c80-4c16-ba22-e1c41cd1dbfe)
