### PR TITLE
김신희 23일차 문제 풀이

### DIFF
--- a/shinhee/ALGO/src/boj_2210/Main.java
+++ b/shinhee/ALGO/src/boj_2210/Main.java
@@ -1,0 +1,50 @@
+package ALGO.src.boj_2210;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int[][] arr;
+    static int[] dx = {1, 0, -1, 0};
+    static int[] dy = {0, 1, 0, -1};
+    static HashSet<String> hashset = new HashSet<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        arr = new int[5][5];
+
+        for (int i = 0; i < 5; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 5; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                dfs(i, j, 0, "");
+            }
+        }
+
+        System.out.println(hashset.size());
+    }
+
+    public static void dfs(int x, int y, int cnt, String s) {
+        if (cnt == 6) {
+            hashset.add(s);
+            return;
+        }
+
+        for (int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if (nx >= 0 && nx < 5 && ny >= 0 && ny < 5) {
+                dfs(nx, ny, cnt + 1, s + arr[nx][ny]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[2210 숫자판 점프](https://www.acmicpc.net/problem/2210)

## 풀이

### 풀이에 대한 직관적인 설명
DFS
### 풀이 도출 과정
DFS, 5×5 숫자판에서 6번 이동하며 숫자를 생성하고, HashSet을 이용해 중복을 제거해 개수를 계산

## 복잡도

* 시간복잡도: O(1)

## 채점 결과
![image](https://github.com/user-attachments/assets/aa749c4f-e24a-4b9e-9857-7bfe0d2a285a)
