### PR TITLE
오동재 24일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_16953/Main.java
+++ b/dongjae/ALGO/src/boj_16953/Main.java
@@ -1,0 +1,46 @@
+package boj_16953;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static String a, b;
+    public static boolean[] visited;
+    public static int answer = -1;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        a = st.nextToken();
+        b = st.nextToken();
+
+        visited = new boolean[1000000001];
+
+        dfs(a, 0);
+        if (answer != -1) System.out.println(answer + 1);
+        else System.out.println(answer);
+    }
+
+    public static void dfs(String now, int depth) {
+        if (now.equals(b)) {
+            answer = depth;
+            return;
+        }
+        visited[Integer.parseInt(now)] = true;
+        String next = null;
+
+        // 곱하기 2
+        next = String.valueOf(Integer.parseInt(now) * 2);
+        if (Long.parseLong(next) <= 1000000000 && !visited[Integer.parseInt(next)]) {
+            dfs(next, depth + 1);
+        }
+
+        // 우측 끝에 1 더하기
+        StringBuilder sb = new StringBuilder();
+        next = sb.append(now).append(1).toString();
+        if (Long.parseLong(next) <= 1000000000 && !visited[Integer.parseInt(next)]) {
+            dfs(next, depth + 1);
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[16953 A -> B](https://www.acmicpc.net/problem/16953)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

완전탐색을 이용한 조건 찾기

### 풀이 도출 과정

필연적으로 BFS가 더 빠를 수 밖에 없는 문제이지만 DFS를 더 연습하고 싶어 DFS로 풀이하였다.

가능한 모든 경우의 수를 두 조건에 따라 완전 탐색한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

주어진 배열의 크기 10^9 만큼의 시간이 소요된다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

![Screenshot 2025-01-08 at 1 55 38 PM](https://github.com/user-attachments/assets/065fab7d-98b2-4800-aa45-db79b5ccd059)
