### PR TITLE
오동재 25일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_1520/Main.java
+++ b/dongjae/ALGO/src/boj_1520/Main.java
@@ -1,0 +1,75 @@
+package boj_1520;
+
+import java.util.*;
+import java.io.*;
+
+class Node {
+    private int x;
+    private int y;
+
+    public Node(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public int getY() {
+        return this.y;
+    }
+}
+
+public class Main {
+    public static int n, m;
+    public static int[][] map = new int[501][501];
+    public static boolean[][] visited = new boolean[501][501];
+    public static int[][] dp = new int[501][501];
+    public static int[] dx = {-1, 0, 1, 0};
+    public static int[] dy = {0, 1, 0, -1};
+    public static int answer = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                dp[i][j] = -1;
+            }
+        }
+
+        System.out.println(dfs(new Node(0, 0)));
+    }
+
+    public static int dfs(Node now) {
+        visited[now.getX()][now.getY()] = true;
+
+        if (now.getX() == (n - 1) && now.getY() == (m - 1)) {
+            return 1;
+        }
+
+        if (dp[now.getX()][now.getY()] != -1) {
+            return dp[now.getX()][now.getY()];
+        }
+
+        dp[now.getX()][now.getY()] = 0;
+        for (int i = 0; i < 4; i++) {
+            int nx = now.getX() + dx[i];
+            int ny = now.getY() + dy[i];
+            if (nx >= 0 && ny >= 0 && nx < n && ny < m) {
+                if (!visited[nx][ny] && map[now.getX()][now.getY()] > map[nx][ny]) {
+                    dp[now.getX()][now.getY()] += dfs(new Node(nx, ny));
+                    visited[nx][ny] = false;
+                }
+            }
+        }
+        return dp[now.getX()][now.getY()];
+    }
+}


### PR DESCRIPTION
## 문제

[1520 내리막 길](https://www.acmicpc.net/problem/1520)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

DFS + DP

### 풀이 도출 과정

BFS를 이용하여 풀이하거나 DFS를 이용하여 풀이하면 메모리 초과 문제가 발생한다.

이미 방문했던 경로에 대해서 두 번 다시 방문하지 않기 위해 dp를 사용해야 한다.

즉 DFS로 완전탐색을 하되 이미 방문한 경로가 등장할 경우 dp 배열의 값을 반환하여 준다.

> 사실 아직도 헷갈림

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n * m)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

![Screenshot 2025-01-08 at 3 56 32 PM](https://github.com/user-attachments/assets/245cd429-490a-448d-b4da-5addf45adcf1)
