### PR TITLE
김효중 25일차 문제 풀이

### DIFF
--- a/hyojung/202501/bog_2331.cpp
+++ b/hyojung/202501/bog_2331.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <queue>
+#include <cmath>
+#include <string>
+#include <map>
+using namespace std;
+
+int visited[1000001];
+int cnt = 1;
+
+int main(void){
+    int a,k;
+    cin >> a >> k;
+
+    for(int i = 1;i<=9999;i++){
+        visited[i] = 0;
+    }
+
+    visited[a] = 1;
+
+    queue<int> q;
+    q.push(a);
+    map<int,int> m;
+    map<int,int>::iterator iter;
+
+    while(!q.empty()){
+        int next = q.front();
+        int sum = 0;
+        q.pop();
+        m[next] = next;
+        if(visited[next] >= 2 && m.find(next) != m.end()){
+            iter = m.find(next);
+            m.erase(iter);
+        }
+        //57
+        
+      
+        for(int i = 0;i<to_string(next).size();i++){
+            int pow_ = pow(to_string(next)[i] - '0',k);
+            sum += pow_;
+        }
+        if(visited[sum] < 3){
+            q.push(sum);
+            visited[sum]++;
+        }
+    }
+    cout << m.size();
+
+}


### PR DESCRIPTION
## 문제

[2331 반복순열](https://www.acmicpc.net/problem/2331)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이
방문배열에 방문한 횟수를 기록하고, 큐에 2번이상 방문한 정수는 map에서 제거해주는 방식.

### 풀이에 대한 직관적인 설명

큐에서 정수를 꺼내고, 그 정수의 각 자릿수의 k 제곱의 합을 계산하기.
계산된 합이 visited 배열에서 3회 미만으로 방문된 경우, 큐에 추가하고 방문 횟수를 증가
만약 해당 정수가 2회 이상 방문되었다면, 맵에서 해당 정수를 제거..

### 풀이 도출 과정


## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도O(n * d)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 
 알고리즘의 시간 복잡도는 O(n * d)로
  n은 최대 1,000,000이고 d는 최대 7이므로, 실제로는 O(n)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/325ce110-5c6f-4e3e-9ee6-218a63a93d00" />

