### PR TITLE
오동재 26일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_4485/Main.java
+++ b/dongjae/ALGO/src/boj_4485/Main.java
@@ -1,0 +1,96 @@
+package boj_4485;
+
+import java.io.*;
+import java.util.*;
+
+class Node implements Comparable<Node> {
+    private int x;
+    private int y;
+    private int cost;
+
+    public Node(int x, int y, int cost) {
+        this.x = x;
+        this.y = y;
+        this.cost = cost;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public int getY() {
+        return this.y;
+    }
+
+    public int getCost() {
+        return this.cost;
+    }
+
+    @Override
+    public int compareTo(Node other) {
+        if (this.cost < other.cost) return -1;
+        else if (this.cost == other.cost) return 0;
+        else return 1;
+    }
+}
+
+public class Main {
+    public static int n;
+    public static int[][] map;
+    public static int[][] d;
+    public static boolean[][] visited;
+    public static int[] dx = {-1, 0, 1, 0};
+    public static int[] dy = {0, 1, 0, -1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int count = 0;
+        while (true) {
+            n = Integer.parseInt(br.readLine());
+            if (n == 0) {
+                break;
+            } else {
+                count += 1;
+                map = new int[n][n];
+                d = new int[n][n];
+                visited = new boolean[n][n];
+                StringTokenizer st;
+                for (int i = 0; i < n; i++) {
+                    st = new StringTokenizer(br.readLine());
+                    for (int j = 0; j < n; j++) {
+                        map[i][j] = Integer.parseInt(st.nextToken());
+                        d[i][j] = Integer.MAX_VALUE;
+                    }
+                }
+                dijkstra(new Node(0, 0, map[0][0]));
+                sb.append("Problem ").append(count).append(": ");
+                sb.append(d[n-1][n-1]).append("\n");
+            }
+        }
+        System.out.print(sb);
+    }
+
+    public static void dijkstra(Node start) {
+        PriorityQueue<Node> pq = new PriorityQueue<>();
+        d[start.getX()][start.getY()] = start.getCost();
+        pq.offer(start);
+        while (!pq.isEmpty()) {
+            Node now = pq.poll();
+            if (!visited[now.getX()][now.getY()]) {
+                for (int i = 0; i < 4; i++) {
+                    int nx = now.getX() + dx[i];
+                    int ny = now.getY() + dy[i];
+                    if (nx >= 0 && ny >= 0 && nx < n && ny < n) {
+                        int cost = now.getCost() + map[nx][ny];
+                        if (d[nx][ny] > cost) {
+                            d[nx][ny] = cost;
+                            pq.offer(new Node(nx, ny, cost));
+                        }
+                    }
+                }
+                visited[now.getX()][now.getY()] = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[4485 녹색 옷 입은 애가 젤다지?](https://www.acmicpc.net/problem/4485)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

인접 행렬 방식에서의 다익스트라

### 풀이 도출 과정

무엇을 간선의 정보로 둘 지, 즉 무엇을 거리의 정보로 둘 것인가가 문제의 핵심이다.

Node 클래스를 이용하여 우선순위 큐에 삽입되는 Node에 현재 위치까지 도달하는데 소모된 루피를 함께 저장한다.

해당 값을 이용하여 루피의 값을 간선의 거리 정보와 같이 이용하여 다익스트라를 이용해 풀이한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^2logn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

총 간선의 개수: `(n-1) * n * 2`

모든 간선 데이터를 힙에 넣었다가 빼는 것이 다익스트라의 총 시간 복잡도이므로 `O(n^2logn^2)`라고 볼 수 있고 이는 로그의 성질에 의해 `O(2*n^2logn)`과 같고 빅오 표기법에서 상수를 무시하면 결론적으로 `O(n^2logn)`의 시간복잡도가 나온다. 

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="857" alt="Screenshot 2025-01-11 at 1 26 10 PM" src="https://github.com/user-attachments/assets/ae94cb4c-fcee-492b-9d60-3d407788fa3d" />
