### PR TITLE
오동재 29일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_1956/Main.java
+++ b/dongjae/ALGO/src/boj_1956/Main.java
@@ -1,0 +1,60 @@
+package boj_1956;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int v, e;
+    public static int[][] graph;
+    public static int INF = (int) 1e9;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        // 입력 받기
+        v = Integer.parseInt(st.nextToken());
+        e = Integer.parseInt(st.nextToken());
+
+        // 그래프 초기화
+        graph = new int[v+1][v+1];
+        for (int i = 1; i <= v; i++) {
+            for (int j = 1; j <= v; j++) {
+                graph[i][j] = INF;
+            }
+        }
+
+        // 간선 정보 입력 받기
+        for (int i = 0; i < e; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            graph[a][b] = c;
+        }
+
+        floyd();
+
+        int result = getMinCycle() == INF ? -1 : getMinCycle();
+        System.out.println(result);
+    }
+
+    public static int getMinCycle() {
+        int min = INF;
+        for (int i = 1; i <= v; i++) {
+            min = Math.min(min, graph[i][i]);
+        }
+        return min;
+    }
+
+    public static void floyd() {
+        for (int k = 1; k <= v; k++) {
+            for (int a = 1; a <= v; a++) {
+                for (int b = 1; b <= v; b++) {
+                    graph[a][b] = Math.min(graph[a][b], graph[a][k] + graph[k][b]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[1956 운동](https://www.acmicpc.net/problem/1956)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

플로이드 워셜

### 풀이 도출 과정

그래프 상 사이클의 최단 경로를 구하고 이 중에서 다시 가장 거리가 짧은 경로의 거리를 다시 반환한다.

처음에 그래프를 초기화할 때 i에서 i로의 거리 테이블을 0이 아닌 다른 경로와 마찬가지로 무한대로 초기화한다.

> 무한대의 기준을 처음에는 `Integer.MAX_VALUE`로 설정했지만 플로이드 워셜의 점화식 중 `graph[a][k] + graph[k][b]`을 계산하는 부분에서 둘 다 `Integer.MAX_VALUE` 일 경우 음수로 저장되는 것을 확인했다. 따라서 적당히 큰 값(10억)을 무한대로 설정해야 한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^3)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

삼중반복문으로 인한 복잡도

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="858" alt="Screenshot 2025-01-14 at 8 55 59 PM" src="https://github.com/user-attachments/assets/8676899c-afd0-4d27-88d3-3b13fb813757" />
