### PR TITLE
강두오 29일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_1446/Main.java
+++ b/duoh/ALGO/src/boj_1446/Main.java
@@ -1,0 +1,78 @@
+package boj_1446;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main {
+	private static final int INF = Integer.MAX_VALUE;
+	private static ArrayList<Node>[] graph;
+	private static int[] dist;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int D = Integer.parseInt(st.nextToken());
+
+		graph = new ArrayList[D + 1];
+		dist = new int[D + 1];
+
+		for (int i = 0; i <= D; i++) {
+			graph[i] = new ArrayList<>();
+			dist[i] = INF;
+
+			if (i < D) {
+				graph[i].add(new Node(i + 1, 1));
+			}
+		}
+
+		while (N-- > 0) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			int c = Integer.parseInt(st.nextToken());
+
+			if (b <= D) {
+				graph[a].add(new Node(b, c));
+			}
+		}
+
+		dijkstra();
+		System.out.println(dist[D]);
+		br.close();
+	}
+
+	private static void dijkstra() {
+		PriorityQueue<Node> pq = new PriorityQueue<>(Comparator.comparingInt(o -> o.w));
+		pq.offer(new Node(0, 0));
+		dist[0] = 0;
+
+		while (!pq.isEmpty()) {
+			Node cur = pq.poll();
+			if (dist[cur.v] < cur.w) continue;
+
+			for (Node next : graph[cur.v]) {
+				if (dist[next.v] > cur.w + next.w) {
+					dist[next.v] = cur.w + next.w;
+					pq.offer(new Node(next.v, dist[next.v]));
+				}
+			}
+		}
+
+	}
+}
+
+class Node {
+	int v, w;
+
+	public Node(int v, int w) {
+		this.v = v;
+		this.w = w;
+	}
+}


### PR DESCRIPTION
## 문제

[1446 지름길](https://www.acmicpc.net/problem/1446)

## 풀이

### 풀이에 대한 직관적인 설명

운전해야하는 거리의 최솟값을 구하는 문제이다.
> dp로도 풀이 가능

### 풀이 도출 과정

- `i -> i + 1` 일반 도로 추가
- 도착점이 `D`를 넘지 않는 지름길만 추가
- 다익스트라

## 복잡도

* 시간복잡도: O(D log D)

개선된 다익스트라 알고리즘

## 채점 결과
<img width="936" alt="스크린샷 2025-01-14 오후 9 16 46" src="https://github.com/user-attachments/assets/12ec8356-73ee-43a4-984e-b82ecc899a6f" />