### PR TITLE
강두오 32일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_10800/Main.java
+++ b/duoh/ALGO/src/boj_10800/Main.java
@@ -1,0 +1,55 @@
+package boj_10800;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int N = Integer.parseInt(br.readLine());
+		Ball[] balls = new Ball[N];
+
+		for (int i = 0; i < N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int c = Integer.parseInt(st.nextToken());
+			int s = Integer.parseInt(st.nextToken());
+			balls[i] = new Ball(i, c, s);
+		}
+
+		Arrays.sort(balls, Comparator.comparingInt(o -> o.size));
+		long[] colorSum = new long[N + 1];
+		long totalSum = 0L;
+		int idx = 0;
+
+		for (int i = 0; i < N; i++) {
+			while (idx < N && balls[idx].size < balls[i].size) {
+				totalSum += balls[idx].size;
+				colorSum[balls[idx].color] += balls[idx].size;
+				idx++;
+			}
+			balls[i].sum = totalSum - colorSum[balls[i].color];
+		}
+
+		Arrays.sort(balls, Comparator.comparingInt(o -> o.idx));
+		StringBuilder sb = new StringBuilder();
+
+		for (Ball ball : balls) {
+			sb.append(ball.sum).append('\n');
+		}
+
+		System.out.println(sb);
+		br.close();
+	}
+}
+
+class Ball {
+	int idx, color, size;
+	long sum;
+
+	public Ball(int idx, int color, int size) {
+		this.idx = idx;
+		this.color = color;
+		this.size = size;
+	}
+}


### PR DESCRIPTION
## 문제

[10800 컬러볼](https://www.acmicpc.net/problem/10800)

## 풀이

### 풀이에 대한 직관적인 설명

각 플레이어가 잡을 수 있는 모든 공들의 크기 합을 구하는 문제이다.

> 플레이어의 공보다 크기가 작고 색이 다른 것만 잡을 수 있다

### 풀이 도출 과정

- 크기 오름차순 정렬
- 두 포인터
  - 현재 공보다 크기가 작은 공만 누적 합에 포함
- 누적 합 계산
  - 전체 누적 합에서 동일한 색의 누적 합을 제외해줌
  - `totalSum - colorSum[balls[i].color]` 
- 인덱스 오름차순 정렬 후 출력

## 복잡도

* 시간복잡도: O(N log N)

정렬 O(N log N), 모든 공 한 번씩 확인 O(N)

## 채점 결과
<img width="936" alt="스크린샷 2025-01-17 오전 11 48 29" src="https://github.com/user-attachments/assets/f7aaa1cf-726e-42df-905c-29a9891e2c91" />