### PR TITLE
강두오 33일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_10800/Main.java
+++ b/duoh/ALGO/src/boj_10800/Main.java
@@ -18,9 +18,8 @@ public class Main {
 		}
 
 		Arrays.sort(balls, Comparator.comparingInt(o -> o.size));
-		long[] colorSum = new long[N + 1];
-		long totalSum = 0L;
-		int idx = 0;
+		int[] colorSum = new int[N + 1];
+		int totalSum = 0, idx = 0;
 
 		for (int i = 0; i < N; i++) {
 			while (idx < N && balls[idx].size < balls[i].size) {
@@ -44,8 +43,7 @@ public class Main {
 }
 
 class Ball {
-	int idx, color, size;
-	long sum;
+	int idx, color, size, sum;
 
 	public Ball(int idx, int color, int size) {
 		this.idx = idx;

--- a/duoh/ALGO/src/boj_15961/Main.java
+++ b/duoh/ALGO/src/boj_15961/Main.java
@@ -1,0 +1,43 @@
+package boj_15961;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int d = Integer.parseInt(st.nextToken());
+		int k = Integer.parseInt(st.nextToken());
+		int c = Integer.parseInt(st.nextToken());
+		int[] belt = new int[N];
+
+		for (int i = 0; i < N; i++) {
+			belt[i] = Integer.parseInt(br.readLine());
+		}
+
+		int[] check = new int[d + 1];
+		int answer, count = 0;
+
+		for (int i = 0; i < k; i++) {
+			if (check[belt[i]]++ == 0)
+				count++;
+		}
+		answer = check[c] == 0 ? count + 1 : count;
+
+		for (int i = 0; i < N; i++) {
+			if (--check[belt[i]] == 0)
+				count--;
+
+			if (check[belt[(i + k) % N]]++ == 0)
+				count++;
+
+			answer = Math.max(answer, check[c] == 0 ? count + 1 : count);
+		}
+
+		System.out.println(answer);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[15961 회전 초밥](https://www.acmicpc.net/problem/15961)

## 풀이

### 풀이에 대한 직관적인 설명

연속된 초밥 `k`개를 선택할 때, 쿠폰 초밥을 포함한 최대 가짓수를 구하는 문제이다.

### 풀이 도출 과정

- 초기화
  - 첫 `k`개의 초밥을 `check` 배열에 추가하여 카운트 계산
  
- 슬라이딩 윈도우
  - 왼쪽 끝 초밥 제거, 오른쪽 새 초밥 추가
  - `check` 배열 값에 따라 카운트 갱신
  
- 쿠폰 초밥 여부
  - `c`가 포함되지 않았다면 추가 계산

- 이동마다 최댓값 갱신

## 복잡도

* 시간복잡도: O(N)

슬라이딩 윈도우

## 채점 결과
<img width="940" alt="스크린샷 2025-01-18 오후 1 09 29" src="https://github.com/user-attachments/assets/63857a93-9c13-45db-a2ca-62bb7bfb1acc" />