### PR TITLE
오동재 33일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_3273/Main.java
+++ b/dongjae/ALGO/src/boj_3273/Main.java
@@ -1,0 +1,44 @@
+package boj_3273;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n, x;
+    public static ArrayList<Integer> array = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            array.add(num);
+        }
+
+        x = Integer.parseInt(br.readLine());
+
+        Collections.sort(array);
+
+        int startIdx = 0;
+        int endIdx = n - 1;
+        int count = 0;
+
+        while (startIdx < endIdx) {
+            int a1 = array.get(startIdx);
+            int a2 = array.get(endIdx);
+            int sum = a1 + a2;
+            if (sum >= x) {
+                if (sum == x) {
+                    count++;
+                }
+                endIdx--;
+            } else {
+                startIdx++;
+            }
+        }
+
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
## 문제

[3273 두 수의 합](https://www.acmicpc.net/problem/3273)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

양 끝에서의 투 포인터

### 풀이 도출 과정

배열을 정렬한 후 양 끝에 포인터를 두어 주어진 합계과 동일한 수의 쌍을 구해준다.

합계가 정답보다 클 경우 endIndex를 하나 줄여주고, 반대일 경우 startIndex를 하나 늘려준다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

배열을 정렬하는 시간 + 투포인터로 합계를 구하는 데 걸리는 시간

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="857" alt="Screenshot 2025-01-20 at 3 14 06 PM" src="https://github.com/user-attachments/assets/e8a200fe-a6eb-469f-b2b9-5d426d57dc42" />
