### PR TITLE
오동재 34일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_2470/Main.java
+++ b/dongjae/ALGO/src/boj_2470/Main.java
@@ -1,0 +1,45 @@
+package boj_2470;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n;
+    public static ArrayList<Integer> array = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            array.add(num);
+        }
+
+        Collections.sort(array);
+
+        int startIdx = 0;
+        int endIdx = n - 1;
+        int[] result = new int[2];
+        int min = Integer.MAX_VALUE;
+
+        while (startIdx < endIdx) {
+            int sum = array.get(startIdx) + array.get(endIdx);
+
+            if (min > Math.abs(sum)) {
+                min = Math.abs(sum);
+                result[0] = array.get(startIdx);
+                result[1] = array.get(endIdx);
+            }
+
+            if (sum > 0) endIdx--;
+            else if (sum == 0) break;
+            else startIdx++;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(result[0]).append(" ").append(result[1]);
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 문제

[2470 두 용액](https://www.acmicpc.net/problem/2470)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

투 포인터

### 풀이 도출 과정

주어진 배열에서 두 가지 용액의 조합이 0에 가까운 경우를 구해야 한다.

이 과정에서 양 끝에 포인터를 두어 0보다 작을 경우 startIdx 값을 증가 시키고, 클 경우 endIdx 값을 증가시킨다.

또한 매번 합계의 절댓값이 최소인 경우를 정답 배열에 갱신한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

투 포인터를 이용한 배열 순회

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="856" alt="Screenshot 2025-01-20 at 4 13 24 PM" src="https://github.com/user-attachments/assets/5e192f74-fc21-42d4-ba3d-62e3bc620a7c" />
