### PR TITLE
오동재 35일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_2473/Main.java
+++ b/dongjae/ALGO/src/boj_2473/Main.java
@@ -1,0 +1,48 @@
+package boj_2473;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n;
+    public static ArrayList<Integer> array = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            array.add(num);
+        }
+
+        Collections.sort(array);
+
+        long min = Long.MAX_VALUE;
+        int[] result = new int[3];
+
+        for (int i = 0; i < n - 2; i++) {
+            int a1 = array.get(i);
+            int startIdx = i + 1;
+            int endIdx = n - 1;
+            while (startIdx < endIdx) {
+                long sum = (long) a1 + array.get(startIdx) + array.get(endIdx);
+                if (Math.abs(sum) < min) {
+                    min = Math.abs(sum);
+                    result[0] = a1;
+                    result[1] = array.get(startIdx);
+                    result[2] = array.get(endIdx);
+                }
+
+                if (sum < 0) startIdx++;
+                else if (sum == 0) break;
+                else endIdx--;
+            }
+        }
+
+        Arrays.sort(result);
+
+        System.out.println(result[0] + " " + result[1] + " " + result[2]);
+    }
+}


### PR DESCRIPTION
## 문제

[2473 세 용액](https://www.acmicpc.net/problem/2473)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

고정된 하나의 용액 + 나머지 합계는 투 포인터

### 풀이 도출 과정

앞에서부터 용액 하나를 고정시켜두고 뒤에 나머지 용액들 중 2개를 골라 합계가 0에 가까운 경우를 기록한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

O(n^2)보다는 작은 시간이 걸린다. 매 계산마다 고정된 값이 포함된 모든 경우의 수를 구할 수 있기 때문에 다음 계산마다 탐색 범위가 1씩 줄어든다. 

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="859" alt="Screenshot 2025-01-20 at 5 33 44 PM" src="https://github.com/user-attachments/assets/f72f2dc1-f36f-454c-89cc-6afec60006fa" />
