### PR TITLE
강두오 35일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_22862/Main.java
+++ b/duoh/ALGO/src/boj_22862/Main.java
@@ -1,0 +1,40 @@
+package boj_22862;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(st.nextToken());
+
+		st = new StringTokenizer(br.readLine());
+		int[] S = new int[N];
+
+		for (int i = 0; i < N; i++) {
+			S[i] = Integer.parseInt(st.nextToken());
+		}
+
+		int left = 0, right = 0, count = 0, answer = 0;
+
+		while (right < N) {
+			if (S[right] % 2 != 0)
+				count++;
+
+			while (count > K) {
+				if (S[left] % 2 != 0)
+					count--;
+				left++;
+			}
+
+			answer = Math.max(answer, right - left + 1 - count);
+			right++;
+		}
+
+		System.out.println(answer);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[22862 가장 긴 짝수 연속한 부분 수열 (large)](https://www.acmicpc.net/problem/22862)

## 풀이

### 풀이에 대한 직관적인 설명

최대 `K`개의 홀수를 제거하여 가장 긴 짝수 부분 수열의 길이를 구하는 문제이다.

### 풀이 도출 과정

- 슬라이딩 윈도우
  - `right++` 이동하며 수열 탐색
  - 홀수인 경우 `count++`
  - `count > K`인 경우 `left++` 이동하며 홀수 개수 감소

- 최댓값 갱신
  - 윈도우 길이에서 홀수 개수를 제외한 값
  - `right - left + 1 - count`

## 복잡도

* 시간복잡도: O(N)

배열 한 번만 순회

## 채점 결과
<img width="940" alt="스크린샷 2025-01-22 오전 9 37 56" src="https://github.com/user-attachments/assets/262a54b7-d81f-48a4-8c1d-ae992a6038fb" />