### PR TITLE
강두오 36일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_1520/Main.java
+++ b/duoh/ALGO/src/boj_1520/Main.java
@@ -1,0 +1,53 @@
+package boj_1520;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static final int[] dx = {0, 0, -1, 1};
+	private static final int[] dy = {1, -1, 0, 0};
+
+	private static int M, N;
+	private static int[][] map, dp;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		M = Integer.parseInt(st.nextToken());
+		N = Integer.parseInt(st.nextToken());
+		map = new int[M][N];
+		dp = new int[M][N];
+
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+
+			for (int j = 0; j < N; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				dp[i][j] = -1;
+			}
+		}
+
+		System.out.println(dfs(0, 0));
+		br.close();
+	}
+
+	private static int dfs(int x, int y) {
+		if (x == M - 1 && y == N - 1)
+			return 1;
+
+		if (dp[x][y] != -1)
+			return dp[x][y];
+
+		dp[x][y] = 0;
+		for (int i = 0; i < 4; i++) {
+			int nx = x + dx[i];
+			int ny = y + dy[i];
+
+			if (nx >= 0 && nx < M && ny >= 0 && ny < N && map[x][y] > map[nx][ny])
+				dp[x][y] += dfs(nx, ny);
+		}
+
+		return dp[x][y];
+	}
+}


### PR DESCRIPTION
## 문제

[1520 내리막 길](https://www.acmicpc.net/problem/1520)

## 풀이

### 풀이에 대한 직관적인 설명

출발지에서 도착지까지 항상 내리막 길로만 이동하는 경로의 개수를 구하는 문제이다.

### 풀이 도출 과정

- dfs + dp
  - dfs 탐색하며, 계산된 결과는 dp 배열에 저장하여 중복 계산 방지
  - 현재 위치에서 상하좌우로 이동하며, 높이가 낮은 경우만 탐색
  - 도착지에 도달하면 1 반환

## 복잡도

* 시간복잡도: O(M * N)

각 위치를 한 번만 탐색함

## 채점 결과
<img width="940" alt="스크린샷 2025-01-23 오후 8 16 50" src="https://github.com/user-attachments/assets/062a8985-1ac3-4a92-961b-446386bb0b55" />