### PR TITLE
오동재 36일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_11053/Main.java
+++ b/dongjae/ALGO/src/boj_11053/Main.java
@@ -1,0 +1,39 @@
+package boj_11053;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n;
+    public static int[] array;
+    public static int[] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        array = new int[n];
+        dp = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            array[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < n; i++) {
+            dp[i] = 1;
+            for (int j = 0; j < i; j++) {
+                if (array[j] < array[i] && dp[i] < dp[j] + 1) {
+                    dp[i] = dp[j] + 1;
+                }
+            }
+        }
+
+        int max = Integer.MIN_VALUE;
+        for (int i = 0; i < n; i++) {
+            max = Math.max(max, dp[i]);
+        }
+
+        System.out.println(max);
+    }
+}


### PR DESCRIPTION
## 문제

[11053 가장 긴 증가하는 부분 수열](https://www.acmicpc.net/problem/11053)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

메모이제이션 기법을 활용한 DP

### 풀이 도출 과정

증가하는 부분 수열을 구하기 위해서 메모이제이션을 활용해서 현재 자신의 원소가 포함된 부분 수열의 길이를 구한다.

반복문을 통해서 이를 갱신한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->

이중 반복문을 통해서 dp 배열을 갱신하기 때문에

## 채점 결과

<!-- 문제 푼 결과 캡처 -->


<img width="860" alt="Screenshot 2025-01-24 at 4 38 24 PM" src="https://github.com/user-attachments/assets/8b8a8900-f1eb-49df-9adf-0cfdf3bdbb4b" />
