### PR TITLE
강두오 37일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_1890/Main.java
+++ b/duoh/ALGO/src/boj_1890/Main.java
@@ -1,0 +1,35 @@
+package boj_1890;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int N = Integer.parseInt(br.readLine());
+		int[][] board = new int[N][N];
+
+		for (int i = 0; i < N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+
+			for (int j = 0; j < N; j++)
+				board[i][j] = Integer.parseInt(st.nextToken());
+		}
+
+		long[][] dp = new long[N][N];
+		dp[0][0] = 1;
+
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < N; j++) {
+				int jump = board[i][j];
+				if (jump == 0) break;
+				if (i + jump < N) dp[i + jump][j] += dp[i][j];
+				if (j + jump < N) dp[i][j + jump] += dp[i][j];
+			}
+		}
+
+		System.out.println(dp[N - 1][N - 1]);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[1890 점프](https://www.acmicpc.net/problem/1890)

## 풀이

### 풀이에 대한 직관적인 설명

출발점에서 도착점까지 규칙에 따라 이동 가능한 경로의 개수를 구하는 문제이다.

### 풀이 도출 과정

- dp 배열로 각 칸까지 도달 가능한 경로의 개수 저장
- 모든 칸을 순회하며 오른쪽과 아래로 이동 가능한 칸에 경로의 개수 누적
- 도착점에 도달하면 `break`

## 복잡도

* 시간복잡도: O(N^2)

모든 칸 순회

## 채점 결과
<img width="940" alt="스크린샷 2025-01-25 오후 9 04 47" src="https://github.com/user-attachments/assets/ca9acc82-6682-451f-9d48-7a5f975c2484" />