### PR TITLE
강두오 38일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_4095/Main.java
+++ b/duoh/ALGO/src/boj_4095/Main.java
@@ -1,0 +1,40 @@
+package boj_4095;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+
+		while (true) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int N = Integer.parseInt(st.nextToken());
+			int M = Integer.parseInt(st.nextToken());
+
+			if (N == 0 && M == 0) break;
+
+			int max = 0;
+			int[][] dp = new int[N][M];
+
+			for (int i = 0; i < N; i++) {
+				st = new StringTokenizer(br.readLine());
+
+				for (int j = 0; j < M; j++) {
+					dp[i][j] = Integer.parseInt(st.nextToken());
+
+					if (i > 0 && j > 0 && dp[i][j] > 0) {
+						dp[i][j] = Math.min(dp[i - 1][j - 1], Math.min(dp[i - 1][j], dp[i][j - 1])) + 1;
+					}
+					max = Math.max(max, dp[i][j]);
+				}
+			}
+
+			sb.append(max).append('\n');
+		}
+
+		System.out.println(sb);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[4095 최대 정사각형](https://www.acmicpc.net/problem/4095)

## 풀이

### 풀이에 대한 직관적인 설명

1과 0으로 이루어진 `N * M`크기의 행렬이 주어졌을 때, 1로만 이루어진 가장 큰 정사각형 부분 행렬을 찾는 문제이다.

### 풀이 도출 과정

- `dp[i][j]` 가 1인 경우 (현재 칸)
  - 왼쪽, 왼쪽 대각선 상단, 상단의 값 중 최소값 + 1로 갱신
  - `Math.min(dp[i - 1][j - 1], Math.min(dp[i - 1][j], dp[i][j - 1])) + 1`
- 최대 크기 갱신

## 복잡도

* 시간복잡도: O(N * M)

모든 칸 순회


## 채점 결과
<img width="940" alt="스크린샷 2025-01-28 오전 9 55 28" src="https://github.com/user-attachments/assets/ef0f8586-6444-4f6a-8bbc-adc0d3da8519" />