### PR TITLE
강두오 39일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_2718/Main.java
+++ b/duoh/ALGO/src/boj_2718/Main.java
@@ -1,0 +1,30 @@
+package boj_2718;
+
+import java.io.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringBuilder sb = new StringBuilder();
+		int T = Integer.parseInt(br.readLine());
+
+		int[] dp = new int[22];
+		dp[0] = 1;
+		dp[1] = 1;
+		dp[2] = 5;
+		dp[3] = 11;
+
+		for (int i = 4; i <= 21; i++) {
+			dp[i] = dp[i - 1] + 5 * dp[i - 2] + dp[i - 3] - dp[i - 4];
+		}
+
+		while (T-- > 0) {
+			int N = Integer.parseInt(br.readLine());
+			sb.append(dp[N]).append('\n');
+		}
+
+		System.out.println(sb);
+		br.close();
+	}
+}


### PR DESCRIPTION
## 문제

[2718 타일 채우기](https://www.acmicpc.net/problem/2718)

## 풀이

### 풀이에 대한 직관적인 설명

`4 * N` 크기의 타일을 채우는 방법의 개수를 구하는 문제이다.

### 풀이 도출 과정

- 다른 타일 채우기 문제와 접근법은 유사함
- 점화식 도출
  - `dp[i] = dp[i - 1] + 5 * dp[i - 2] + dp[i - 3] - dp[i - 4]`

## 복잡도

* 시간복잡도: O(N)

점화식을 통해 dp 배열 계산

## 채점 결과
<img width="940" alt="스크린샷 2025-01-28 오후 4 13 31" src="https://github.com/user-attachments/assets/018a36a1-da32-4714-a3a5-1e60cd9999de" />