### PR TITLE
오동재 38일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_9461/Main.java
+++ b/dongjae/ALGO/src/boj_9461/Main.java
@@ -1,0 +1,30 @@
+package boj_9461;
+
+import java.io.*;
+
+public class Main {
+    public static int t, n;
+    public static long[] dp = new long[101];
+
+    public static void main(String[] args) throws IOException {
+        padovan();
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        t = Integer.parseInt(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < t; i++) {
+            n = Integer.parseInt(br.readLine());
+            sb.append(dp[n]).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    public static void padovan() {
+        dp[0] = 0;
+        dp[1] = 1;
+        dp[2] = 1;
+        dp[3] = 1;
+        for (int i = 4; i <= 100; i++) {
+            dp[i] = dp[i-2] + dp[i-3];
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[9461 파도반 수열](https://www.acmicpc.net/problem/9461)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

점화식 + 보텀업

### 풀이 도출 과정

점화식: `f(n) = f(n-2) + f(n-3)`

보텀업 방식으로 반복문을 이용해 dp 배열을 채워주고 시작한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

크기가 n인 dp 배열을 채우는데 걸리는 시간

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="858" alt="Screenshot 2025-01-28 at 10 41 23 PM" src="https://github.com/user-attachments/assets/59929fff-49ce-4e46-97be-c6fc04494ac3" />