### PR TITLE
강두오 40일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_2098/Main.java
+++ b/duoh/ALGO/src/boj_2098/Main.java
@@ -1,0 +1,55 @@
+package boj_2098;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static final int INF = Integer.MAX_VALUE / 2;
+	private static int N;
+	private static int[][] W, dp;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		N = Integer.parseInt(br.readLine());
+		W = new int[N][N];
+		dp = new int[N][1 << N];
+
+		for (int i = 0; i < N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			Arrays.fill(dp[i], -1);
+
+			for (int j = 0; j < N; j++) {
+				W[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		System.out.println(dfs(0, 1));
+		br.close();
+	}
+
+	private static int dfs(int cur, int visited) {
+		// 모든 도시 방문 완료
+		if (visited == (1 << N) - 1) {
+			// 출발 도시로 돌아가는 길이 존재하지 않으면 INF
+			return W[cur][0] == 0 ? INF : W[cur][0];
+		}
+
+		// 이미 방문한 도시
+		if (dp[cur][visited] != -1) {
+			return dp[cur][visited];
+		}
+		dp[cur][visited] = INF;
+
+		// 방문하지 않은 도시 탐색
+		for (int i = 1; i < N; i++) {
+			// 방문하지 않았고, 경로가 존재하는 경우
+			if ((visited & (1 << i)) == 0 && W[cur][i] != 0) {
+				int next = visited | (1 << i);
+				dp[cur][visited] = Math.min(dp[cur][visited], dfs(i, next) + W[cur][i]);
+			}
+		}
+
+		return dp[cur][visited];
+	}
+}


### PR DESCRIPTION
## 문제

[2098 외판원 순회](https://www.acmicpc.net/problem/2098)

## 풀이

### 풀이에 대한 직관적인 설명

`N`개의 도시를 한 번씩 방문한 후, 다시 출발 도시로 돌아오는 최소 비용을 구하는 문제이다.
> 외판원 순회 기본 문제

### 풀이 도출 과정

- 비트마스킹 + DP
- `dp[cur][visited]`
  - 현재 `cur` 도시에 있고, `visited` 상태에서 남은 도시를 모두 방문한 후 출발 도시로 돌아오는 최소 비용 저장
- 모든 도시 방문 완료 시, 출발 도시로 돌아갈 수 있으면 해당 비용, 없으면 INF 반환
- 방문하지 않은 도시를 탐색하며 `dp[cur][visited]` 갱신
 
## 복잡도

* 시간복잡도: O(N^2 * 2^N)

`N * (1 << N)` 크기의 dp 배열에서 각 위치마다 O(N) 탐색

## 채점 결과
<img width="940" alt="스크린샷 2025-01-29 오전 11 13 52" src="https://github.com/user-attachments/assets/1de5d2fa-51c9-4794-b1e7-e55ec3a9ee47" />