### PR TITLE
오동재 39일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_1912/Main.java
+++ b/dongjae/ALGO/src/boj_1912/Main.java
@@ -1,0 +1,32 @@
+package boj_1912;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n;
+    public static int[] array;
+    public static int[] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        array = new int[n];
+        dp = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            array[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dp[0] = array[0];
+        int max = dp[0];
+        for (int i = 1; i < n; i++) {
+            dp[i] = Math.max(dp[i-1] + array[i], array[i]);
+            max = Math.max(max, dp[i]);
+        }
+
+        System.out.println(max);
+    }
+}


### PR DESCRIPTION
## 문제

[1912 연속합](https://www.acmicpc.net/problem/1912)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

직전 배열까지의 경우에서 최대의 합 + 현재 원소, 현재 원소 중 큰 값 구하기

### 풀이 도출 과정

`f(n) = max(f(n-1) + An, An)`

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

보텀업 방식의 배열 채우기

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="855" alt="Screenshot 2025-01-29 at 10 07 11 PM" src="https://github.com/user-attachments/assets/f4110684-f48b-4b7f-8a24-5469129d2d0a" />
