### PR TITLE
오동재 40일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_11727/Main.java
+++ b/dongjae/ALGO/src/boj_11727/Main.java
@@ -1,0 +1,22 @@
+package boj_11727;
+
+import java.io.*;
+
+public class Main {
+    public static int n;
+    public static int[] dp = new int[1001];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        dp[1] = 1;
+        dp[2] = 3;
+        for (int i = 3; i <= n; i++) {
+            dp[i] = (dp[i-1] + dp[i-2] * 2) % 10007;
+        }
+
+        System.out.println(dp[n]);
+    }
+}
+


### PR DESCRIPTION
## 문제

[11727 2×n 타일링 2](https://www.acmicpc.net/problem/11727)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

단순 점화식 도출 후 그대로 풀이

### 풀이 도출 과정

`f(n) = f(n-1) + f(n-2) * 2`

dp 배열에 값을 그대로 저장하면 오버플로우가 발생할 수 있어 나머지 값을 계산하여 저장한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

n만큼 반복하여 dp 배열을 채움

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="857" alt="Screenshot 2025-01-29 at 10 39 33 PM" src="https://github.com/user-attachments/assets/f3e37e75-76e9-435d-8cbe-dca740694d4f" />
