### PR TITLE
강두오 42일차 문제 풀이

### DIFF
--- a/duoh/ALGO/src/boj_1182/Main.java
+++ b/duoh/ALGO/src/boj_1182/Main.java
@@ -1,0 +1,38 @@
+package boj_1182;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static int N, S, count;
+	private static int[] arr;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		S = Integer.parseInt(st.nextToken());
+
+		arr = new int[N];
+		st = new StringTokenizer(br.readLine());
+
+		for (int i = 0; i < N; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+
+		dfs(0, 0);
+		System.out.println(S == 0 ? count - 1 : count);
+		br.close();
+	}
+
+	private static void dfs(int depth, int sum) {
+		if (depth == N) {
+			if (sum == S) count++;
+			return;
+		}
+
+		dfs(depth + 1, sum + arr[depth]);
+		dfs(depth + 1, sum);
+	}
+}


### PR DESCRIPTION
## 문제

[1182 부분수열의 합](https://www.acmicpc.net/problem/1182)

## 풀이

### 풀이에 대한 직관적인 설명

합이 `S`가 되는 부분수열의 개수를 구하는 문제이다.


### 풀이 도출 과정

- 백트래킹
  - `dfs(depth, sum)`: 현재 원소를 선택할지 말지 결정
  - `depth == N`이면 모든 원소에 대한 선택이 끝남
  - `sum == S`인 경우만 `count++`
- `S == 0`인 경우, 공집합을 제외해줌

## 복잡도

* 시간복잡도: O(2^N)

각 원소를 선택할지 말지.. 경우의 수 2^N

## 채점 결과
<img width="940" alt="스크린샷 2025-02-04 오전 11 50 01" src="https://github.com/user-attachments/assets/34a523fb-1688-42a0-8927-dc630de0e234" />