### PR TITLE
오동재 51일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_2573/Main.java
+++ b/dongjae/ALGO/src/boj_2573/Main.java
@@ -1,0 +1,120 @@
+package boj_2573;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    private int x;
+    private int y;
+
+    public Node(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public int getY() {
+        return this.y;
+    }
+}
+
+public class Main {
+    public static int n, m;
+    public static int[][] map;
+    public static int[] dx = {-1, 0, 1, 0};
+    public static int[] dy = {0, -1, 0, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        map = new int[n][m];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int answer = 0;
+        int count = 0;
+
+        while ((count = countIce()) < 2) {
+            if (count == 0) {
+                answer = 0;
+                break;
+            }
+            bfs();
+            answer++;
+        }
+
+        System.out.println(answer);
+    }
+
+    public static int countIce() {
+        boolean[][] visited = new boolean[n][m];
+        int count = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (map[i][j] != 0 && !visited[i][j]) {
+                    dfs(i, j, visited);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    public static void dfs(int x, int y, boolean[][] visited) {
+        visited[x][y] = true;
+        for (int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+            if (nx >= 0 && ny >= 0 && nx < n && ny < m) {
+                if (map[nx][ny] != 0 && !visited[nx][ny]) {
+                    dfs(nx, ny, visited);
+                }
+            }
+        }
+    }
+
+    public static void bfs() {
+        Queue<Node> q = new LinkedList<>();
+
+        boolean[][] visited = new boolean[n][m];
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (map[i][j] != 0) {
+                    q.offer(new Node(i, j));
+                    visited[i][j] = true;
+                }
+            }
+        }
+
+        while (!q.isEmpty()) {
+            Node now = q.poll();
+            int seaNum = 0;
+            for (int i = 0; i < 4; i++) {
+                int nx = now.getX() + dx[i];
+                int ny = now.getY() + dy[i];
+                if (nx >= 0 && ny >= 0 && nx < n && ny < m) {
+                    if (!visited[nx][ny] && map[nx][ny] == 0) {
+                        seaNum++;
+                    }
+                }
+            }
+            if (map[now.getX()][now.getY()] - seaNum < 0) {
+                map[now.getX()][now.getY()] = 0;
+            } else {
+                map[now.getX()][now.getY()] -= seaNum;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[2573 빙산](https://www.acmicpc.net/problem/2573)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

* 빙산 덩어리의 개수를 구할 때는 DFS, 녹이는 과정에서는 BFS

### 풀이 도출 과정

1. 빙산이 한 덩어리일 경우 빙하를 녹인다.
2. 두 덩어리 이상 나누어지기 전에 빙하가 전부 녹아버린다면 0을 출력한다.
3. 두 덩어리 이상 나누어졌다면, 빙하를 그만 녹이고 반복 횟수를 출력한다.
4. 여전히 한 덩어리라면, 1번 과정으로 되돌아간다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O((n*m)^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

한 번의 시뮬레이션에서 `O(n*m)` 의 시간이 걸리고 해당 시뮬레이션이 최악의 경우 `O(n*m)` 실행될 수 있기 때문

## 채점 결과

<img width="858" alt="Screenshot 2025-02-17 at 11 20 10 PM" src="https://github.com/user-attachments/assets/e0d5499d-163b-4469-a3b6-3aa19d75cb57" />

<!-- 문제 푼 결과 캡처 -->
