### PR TITLE
오동재 52일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_1967/Main.java
+++ b/dongjae/ALGO/src/boj_1967/Main.java
@@ -1,0 +1,67 @@
+package boj_1967;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    private int x;
+    private int distance;
+
+    public Node(int x, int distance) {
+        this.x = x;
+        this.distance = distance;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public int getDistance() {
+        return this.distance;
+    }
+}
+
+public class Main {
+    public static int n;
+    public static ArrayList<ArrayList<Node>> graph = new ArrayList<>();
+    public static boolean[][] visited;
+    public static int max = Integer.MIN_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        visited = new boolean[n+1][n+1];
+
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < n-1; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            graph.get(a).add(new Node(b, c));
+            graph.get(b).add(new Node(a, c));
+        }
+
+        for (int i = 1; i <= n; i++) {
+            dfs(i, new Node(i, 0), 0);
+        }
+
+        System.out.println(max);
+    }
+
+    public static void dfs(int start, Node now, int prev) {
+        visited[start][now.getX()] = true;
+        for (int i = 0; i < graph.get(now.getX()).size(); i++) {
+            Node next = graph.get(now.getX()).get(i);
+            if (!visited[start][next.getX()]) {
+                max = Math.max(max, prev + next.getDistance());
+                dfs(start, next, prev + next.getDistance());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[1967 트리의 지름](https://www.acmicpc.net/problem/1967)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

모든 노드에서 모든 노드까지의 거리를 DFS를 이용하여 구하고 그 중에서 가장 긴 거리를 구한다.

### 풀이 도출 과정

트리의 성질 중 문제에 제시된대로 한 노드에서 다른 노드까지의 경로는 항상 일정하다.

이 점을 이용해서 다른 노드를 한 번 방문할 때마다 해당 노드까지의 거리를 계산한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

O(n)의 시간복잡도를 가지는 연산을 총 n번 수행하기 때문

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="858" alt="Screenshot 2025-02-18 at 10 02 05 PM" src="https://github.com/user-attachments/assets/3e91a2e7-bb1d-43f5-a34b-2a28bce297ec" />
