### PR TITLE
오동재 53일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_1926/Main.java
+++ b/dongjae/ALGO/src/boj_1926/Main.java
@@ -1,0 +1,62 @@
+package boj_1926;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n, m;
+    public static int[][] map;
+    public static boolean[][] visited;
+    public static int[] dx = {-1, 0, 1, 0};
+    public static int[] dy = {0, -1, 0, 1};
+    public static int area;
+    public static int areaCount = 0;
+    public static int max = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        map = new int[n][m];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        visited = new boolean[n][m];
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (!visited[i][j] && map[i][j] == 1) {
+                    area = 1;
+                    dfs(i, j);
+                    areaCount++;
+                    max = Math.max(max, area);
+                }
+            }
+        }
+
+        System.out.println(areaCount);
+        System.out.println(max);
+    }
+
+    public static void dfs(int x, int y) {
+        visited[x][y] = true;
+        for (int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+            if (nx >= 0 && ny >= 0 && nx < n && ny < m) {
+                if (!visited[nx][ny] && map[nx][ny] == 1) {
+                    area++;
+                    dfs(nx, ny);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[1926 그림](https://www.acmicpc.net/problem/1926)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

DFS를 이용한 영역 갯수 구하기 + 영역 면적 구하기

### 풀이 도출 과정

간단하게 1이 등장할 때마다 DFS를 통해 영역의 면적을 구하고 count 변수의 값을 1 증가시킨다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

한 번 DFS를 수행할 때마다 O(n)의 시간이 걸리고 이를 n번 수행하기 때문.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="857" alt="Screenshot 2025-02-18 at 10 50 56 PM" src="https://github.com/user-attachments/assets/f866f2ae-0c6c-4f12-80c5-f39a58345e2c" />