### PR TITLE
오동재 54일차 문제 풀이

### DIFF
--- a/dongjae/ALGO/src/boj_1167/Main.java
+++ b/dongjae/ALGO/src/boj_1167/Main.java
@@ -1,0 +1,77 @@
+package boj_1167;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    private int x;
+    private int distance;
+
+    public Node(int x, int distance) {
+        this.x = x;
+        this.distance = distance;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public int getDistance() {
+        return this.distance;
+    }
+}
+
+public class Main {
+    public static int v;
+    public static ArrayList<ArrayList<Node>> graph = new ArrayList<>();
+    public static boolean[] visited;
+    public static int farthestNode, maxDistance;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        v = Integer.parseInt(br.readLine());
+
+        visited = new boolean[v+1];
+
+        for (int i = 0; i <= v; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < v; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int num = Integer.parseInt(st.nextToken());
+            while (true) {
+                int x = Integer.parseInt(st.nextToken());
+                if (x == -1) break;
+                int y = Integer.parseInt(st.nextToken());
+
+                graph.get(num).add(new Node(x, y));
+            }
+        }
+
+        visited = new boolean[v + 1];
+        maxDistance = 0;
+        dfs(1, 0);
+
+        visited = new boolean[v + 1];
+        maxDistance = 0;
+        dfs(farthestNode, 0);
+
+        System.out.println(maxDistance);
+    }
+
+    public static void dfs(int node, int dist) {
+        visited[node] = true;
+        if (dist > maxDistance) {
+            maxDistance = dist;
+            farthestNode = node;
+        }
+
+        for (Node next : graph.get(node)) {
+            if (!visited[next.getX()]) {
+                dfs(next.getX(), dist + next.getDistance());
+            }
+        }
+    }
+}

--- a/dongjae/ALGO/src/boj_2675/Main.java
+++ b/dongjae/ALGO/src/boj_2675/Main.java
@@ -1,0 +1,32 @@
+package boj_2675;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int t;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        t = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < t; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int r = Integer.parseInt(st.nextToken());
+            String s = st.nextToken();
+            char[] charArray = s.toCharArray();
+
+            for (int j = 0; j < s.length(); j++) {
+                for (int k = 0; k < r; k++) {
+                    sb.append(charArray[j]);
+                }
+            }
+
+            sb.append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 문제

[1167 트리의 지름](https://www.acmicpc.net/problem/1167)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

앞서 풀었던 트리의 지름 구하기 문제와 내용은 동일하지만 같은 방법으로 풀 경우 메모리 초과가 난다.

### 풀이 도출 과정

1. 임의의 한 점에서 가장 먼 정점을 구한다.
2. 그 정점에서 다시 DFS를 수행하여 가장 먼 거리(트리의 지름)를 찾는다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(v + e)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

dfs에서 각 노드와 간선을 한 번씩 방문하기 때문

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="860" alt="Screenshot 2025-02-21 at 5 37 03 PM" src="https://github.com/user-attachments/assets/041869f7-59f3-4bdd-9d32-9b1b308bbff1" />
